### PR TITLE
Add version information

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -205,6 +205,7 @@
                 <includes>
                     <include>**/*.*</include>
                 </includes>
+                <filtering>true</filtering>
             </resource>
         </resources>
 
@@ -343,6 +344,21 @@
                         <goals>
                         <goal>jar</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>io.github.git-commit-id</groupId>
+                <artifactId>git-commit-id-maven-plugin</artifactId>
+                <version>5.0.0</version>
+                <executions>
+                    <execution>
+                        <id>get-the-git-infos</id>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                        <phase>initialize</phase>
                     </execution>
                 </executions>
             </plugin>

--- a/src/main/java/nl/tudelft/cse1110/andy/AndyOnWebLab.java
+++ b/src/main/java/nl/tudelft/cse1110/andy/AndyOnWebLab.java
@@ -1,6 +1,7 @@
 package nl.tudelft.cse1110.andy;
 
 import nl.tudelft.cse1110.andy.execution.mode.Action;
+import nl.tudelft.cse1110.andy.utils.PropertyUtils;
 import nl.tudelft.cse1110.andy.writer.standard.RandomAsciiArtGenerator;
 import nl.tudelft.cse1110.andy.writer.weblab.WebLabResultWriter;
 
@@ -23,7 +24,7 @@ public class AndyOnWebLab {
         if (workDir == null) { System.out.println("No WORKING_DIR environment variable."); System.exit(-1); }
         if (outputDir == null) { System.out.println("No OUTPUT_DIR environment variable.");  System.exit(-1); }
 
-        WebLabResultWriter writer = new WebLabResultWriter(new RandomAsciiArtGenerator());
+        WebLabResultWriter writer = new WebLabResultWriter(PropertyUtils.getVersionInformation(), new RandomAsciiArtGenerator());
         new Andy(getAction(action), workDir, outputDir, writer).run();
     }
 

--- a/src/main/java/nl/tudelft/cse1110/andy/AndyOnWebLab.java
+++ b/src/main/java/nl/tudelft/cse1110/andy/AndyOnWebLab.java
@@ -24,7 +24,7 @@ public class AndyOnWebLab {
         if (workDir == null) { System.out.println("No WORKING_DIR environment variable."); System.exit(-1); }
         if (outputDir == null) { System.out.println("No OUTPUT_DIR environment variable.");  System.exit(-1); }
 
-        WebLabResultWriter writer = new WebLabResultWriter(PropertyUtils.getVersionInformation(), new RandomAsciiArtGenerator());
+        WebLabResultWriter writer = new WebLabResultWriter();
         new Andy(getAction(action), workDir, outputDir, writer).run();
     }
 

--- a/src/main/java/nl/tudelft/cse1110/andy/utils/PropertyUtils.java
+++ b/src/main/java/nl/tudelft/cse1110/andy/utils/PropertyUtils.java
@@ -1,0 +1,30 @@
+package nl.tudelft.cse1110.andy.utils;
+
+import nl.tudelft.cse1110.andy.writer.standard.VersionInformation;
+
+import java.io.IOException;
+import java.util.Properties;
+
+public class PropertyUtils {
+    public static VersionInformation getVersionInformation() {
+        Properties versionProperties = new Properties();
+        VersionInformation versionInformation;
+        try {
+            versionProperties.load(PropertyUtils.class.getClassLoader().getResourceAsStream("version.properties"));
+            versionInformation = new VersionInformation(
+                    versionProperties.getProperty("project.version"),
+                    versionProperties.getProperty("git.build.time"),
+                    versionProperties.getProperty("git.commit.id")
+            );
+        } catch (IOException e) {
+            System.out.println("Could not load Andy version information");
+            e.printStackTrace();
+            versionInformation = new VersionInformation(
+                    "INVALID_VERSION",
+                    "INVALID_BUILD_TIMESTAMP",
+                    "INVALID_COMMIT_ID");
+        }
+
+        return versionInformation;
+    }
+}

--- a/src/main/java/nl/tudelft/cse1110/andy/writer/standard/StandardResultWriter.java
+++ b/src/main/java/nl/tudelft/cse1110/andy/writer/standard/StandardResultWriter.java
@@ -31,12 +31,8 @@ public class StandardResultWriter implements ResultWriter {
         this.asciiArtGenerator = asciiArtGenerator;
     }
 
-    public StandardResultWriter(VersionInformation versionInformation) {
-        this(versionInformation, new RandomAsciiArtGenerator());
-    }
-
     public StandardResultWriter() {
-        this(PropertyUtils.getVersionInformation());
+        this(PropertyUtils.getVersionInformation(), new RandomAsciiArtGenerator());
     }
 
     @Override

--- a/src/main/java/nl/tudelft/cse1110/andy/writer/standard/StandardResultWriter.java
+++ b/src/main/java/nl/tudelft/cse1110/andy/writer/standard/StandardResultWriter.java
@@ -5,6 +5,7 @@ import nl.tudelft.cse1110.andy.execution.mode.ModeActionSelector;
 import nl.tudelft.cse1110.andy.result.*;
 import nl.tudelft.cse1110.andy.utils.ExceptionUtils;
 import nl.tudelft.cse1110.andy.utils.ImportUtils;
+import nl.tudelft.cse1110.andy.utils.PropertyUtils;
 import nl.tudelft.cse1110.andy.writer.ResultWriter;
 import nl.tudelft.cse1110.andy.writer.weblab.Highlight;
 
@@ -31,8 +32,11 @@ public class StandardResultWriter implements ResultWriter {
     }
 
     public StandardResultWriter(VersionInformation versionInformation) {
-        this.versionInformation = versionInformation;
-        this.asciiArtGenerator = new RandomAsciiArtGenerator();
+        this(versionInformation, new RandomAsciiArtGenerator());
+    }
+
+    public StandardResultWriter() {
+        this(PropertyUtils.getVersionInformation());
     }
 
     @Override

--- a/src/main/java/nl/tudelft/cse1110/andy/writer/standard/StandardResultWriter.java
+++ b/src/main/java/nl/tudelft/cse1110/andy/writer/standard/StandardResultWriter.java
@@ -19,16 +19,19 @@ import static nl.tudelft.cse1110.andy.utils.FilesUtils.writeToFile;
 
 public class StandardResultWriter implements ResultWriter {
 
+    private final VersionInformation versionInformation;
     private final RandomAsciiArtGenerator asciiArtGenerator;
 
     private StringBuilder toDisplay = new StringBuilder();
     private List<Highlight> highlights = new ArrayList<>();
 
-    public StandardResultWriter(RandomAsciiArtGenerator asciiArtGenerator) {
+    public StandardResultWriter(VersionInformation versionInformation, RandomAsciiArtGenerator asciiArtGenerator) {
+        this.versionInformation = versionInformation;
         this.asciiArtGenerator = asciiArtGenerator;
     }
 
-    public StandardResultWriter() {
+    public StandardResultWriter(VersionInformation versionInformation) {
+        this.versionInformation = versionInformation;
         this.asciiArtGenerator = new RandomAsciiArtGenerator();
     }
 
@@ -50,6 +53,7 @@ public class StandardResultWriter implements ResultWriter {
     }
 
     private void writeStdOutFile(Context ctx, Result result) {
+        printVersionInformation();
 
         if(result.hasGenericFailure()) {
             toDisplay.append(result.getGenericFailure());
@@ -272,7 +276,13 @@ public class StandardResultWriter implements ResultWriter {
         }
     }
 
-
+    private void printVersionInformation() {
+        l(String.format("Andy v%s-%s (%s)\n",
+                versionInformation.getVersion(),
+                versionInformation.getCommitId(),
+                versionInformation.getBuildTimestamp()
+        ));
+    }
 
     private void l(String line) {
         toDisplay.append(line);

--- a/src/main/java/nl/tudelft/cse1110/andy/writer/standard/VersionInformation.java
+++ b/src/main/java/nl/tudelft/cse1110/andy/writer/standard/VersionInformation.java
@@ -1,0 +1,25 @@
+package nl.tudelft.cse1110.andy.writer.standard;
+
+public class VersionInformation {
+    private String version;
+    private String buildTimestamp;
+    private String commitId;
+
+    public VersionInformation(String version, String buildTimestamp, String commitId) {
+        this.version = version;
+        this.buildTimestamp = buildTimestamp;
+        this.commitId = commitId;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public String getBuildTimestamp() {
+        return buildTimestamp;
+    }
+
+    public String getCommitId() {
+        return commitId;
+    }
+}

--- a/src/main/java/nl/tudelft/cse1110/andy/writer/weblab/WebLabResultWriter.java
+++ b/src/main/java/nl/tudelft/cse1110/andy/writer/weblab/WebLabResultWriter.java
@@ -20,6 +20,10 @@ public class WebLabResultWriter extends StandardResultWriter {
         super(versionInformation, asciiArtGenerator);
     }
 
+    public WebLabResultWriter() {
+        super();
+    }
+
     @Override
     public void write(Context ctx, Result result) {
 

--- a/src/main/java/nl/tudelft/cse1110/andy/writer/weblab/WebLabResultWriter.java
+++ b/src/main/java/nl/tudelft/cse1110/andy/writer/weblab/WebLabResultWriter.java
@@ -5,6 +5,7 @@ import nl.tudelft.cse1110.andy.execution.Context;
 import nl.tudelft.cse1110.andy.result.*;
 import nl.tudelft.cse1110.andy.writer.standard.RandomAsciiArtGenerator;
 import nl.tudelft.cse1110.andy.writer.standard.StandardResultWriter;
+import nl.tudelft.cse1110.andy.writer.standard.VersionInformation;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -15,8 +16,8 @@ import static nl.tudelft.cse1110.andy.utils.FilesUtils.writeToFile;
 
 public class WebLabResultWriter extends StandardResultWriter {
 
-    public WebLabResultWriter(RandomAsciiArtGenerator asciiArtGenerator) {
-        super(asciiArtGenerator);
+    public WebLabResultWriter(VersionInformation versionInformation, RandomAsciiArtGenerator asciiArtGenerator) {
+        super(versionInformation, asciiArtGenerator);
     }
 
     @Override

--- a/src/main/resources/version.properties
+++ b/src/main/resources/version.properties
@@ -1,0 +1,3 @@
+project.version=${project.version}
+git.commit.id=${git.commit.id.abbrev}
+git.build.time=${git.build.time}

--- a/src/test/java/integration/WebLabTest.java
+++ b/src/test/java/integration/WebLabTest.java
@@ -3,6 +3,7 @@ package integration;
 import nl.tudelft.cse1110.andy.execution.mode.Action;
 import nl.tudelft.cse1110.andy.writer.ResultWriter;
 import nl.tudelft.cse1110.andy.writer.standard.RandomAsciiArtGenerator;
+import nl.tudelft.cse1110.andy.writer.standard.VersionInformation;
 import nl.tudelft.cse1110.andy.writer.weblab.WebLabResultWriter;
 import org.junit.jupiter.api.Test;
 
@@ -15,7 +16,8 @@ public class WebLabTest extends IntegrationTestBase {
 
     protected ResultWriter getWriter() {
         RandomAsciiArtGenerator generator = new RandomAsciiArtGenerator();
-        return new WebLabResultWriter(generator);
+        VersionInformation versionInformation = new VersionInformation("testVersion", "testBuildTimestamp", "testCommitId");
+        return new WebLabResultWriter(versionInformation, generator);
     }
 
     @Test

--- a/src/test/java/unit/writer/standard/StandardResultTestAssertions.java
+++ b/src/test/java/unit/writer/standard/StandardResultTestAssertions.java
@@ -1,6 +1,7 @@
 package unit.writer.standard;
 
 import nl.tudelft.cse1110.andy.utils.FilesUtils;
+import nl.tudelft.cse1110.andy.writer.standard.VersionInformation;
 import org.apache.commons.lang.StringUtils;
 import org.assertj.core.api.Condition;
 
@@ -79,6 +80,16 @@ public class StandardResultTestAssertions {
 
     public static Condition<String> compilationErrorType(String errorType) {
         return containsRegex("- line \\d+: " + errorType);
+    }
+
+    public static Condition<String> versionInformation(String version, String commitId, String timestamp) {
+        return containsString(String.format("Andy v%s-%s (%s)\n", version, commitId, timestamp));
+    }
+
+    public static Condition<String> versionInformation(VersionInformation versionInformation) {
+        return versionInformation(versionInformation.getVersion(),
+                versionInformation.getCommitId(),
+                versionInformation.getBuildTimestamp());
     }
 
     public static Condition<String> partiallyCoveredLine(int line) {

--- a/src/test/java/unit/writer/standard/StandardResultWriterTest.java
+++ b/src/test/java/unit/writer/standard/StandardResultWriterTest.java
@@ -70,6 +70,7 @@ public class StandardResultWriterTest {
         String output = generatedResult();
 
         assertThat(output)
+                .has(versionInformation(versionInformation))
                 .has(finalGradeNotOnScreen(0))
                 .has(noFinalGrade())
                 .has(not(compilationSuccess()))
@@ -93,6 +94,7 @@ public class StandardResultWriterTest {
         String output = generatedResult();
 
         assertThat(output)
+                .has(versionInformation(versionInformation))
                 .has(not(compilationSuccess()))
                 .has(compilationFailure())
                 .has(compilationFailureConfigurationError());
@@ -109,6 +111,7 @@ public class StandardResultWriterTest {
         String output = generatedResult();
 
         assertThat(output)
+                .has(versionInformation(versionInformation))
                 .has(finalGradeNotOnScreen(0))
                 .has(noFinalGrade())
                 .has(genericFailure("test failure"));
@@ -132,6 +135,7 @@ public class StandardResultWriterTest {
         String output = generatedResult();
 
         assertThat(output)
+                .has(versionInformation(versionInformation))
                 .has(finalGradeNotOnScreen(0))
                 .has(noFinalGrade())
                 .has(compilationSuccess())
@@ -179,6 +183,7 @@ public class StandardResultWriterTest {
         String output = generatedResult();
 
         assertThat(output)
+                .has(versionInformation(versionInformation))
                 .has(finalGradeOnScreen(34))
                 .has(compilationSuccess())
                 .has(linesCovered(4))
@@ -220,6 +225,7 @@ public class StandardResultWriterTest {
         String output = generatedResult();
 
         assertThat(output)
+                .has(versionInformation(versionInformation))
                 .has(finalGradeOnScreen(34))
                 .has(compilationSuccess())
                 .has(linesCovered(4))
@@ -270,6 +276,7 @@ public class StandardResultWriterTest {
         String output = generatedResult();
 
         assertThat(output)
+                .has(versionInformation(versionInformation))
                 .has(finalGradeNotOnScreen(34))
                 .has(noFinalGrade())
                 .has(compilationSuccess())
@@ -306,6 +313,7 @@ public class StandardResultWriterTest {
         String output = generatedResult();
 
         assertThat(output)
+                .has(versionInformation(versionInformation))
                 .has(finalGradeOnScreen(0))
                 .has(not(compilationSuccess()))
                 .has(compilationFailure())
@@ -338,6 +346,7 @@ public class StandardResultWriterTest {
         String output = generatedResult();
 
         assertThat(output)
+                .has(versionInformation(versionInformation))
                 .has(finalGradeOnScreen(100))
                 .contains("random ascii art");
     }
@@ -381,6 +390,7 @@ public class StandardResultWriterTest {
         String output = generatedResult();
 
         assertThat(output)
+                .has(versionInformation(versionInformation))
                 .has(finalGradeOnScreen(34))
                 .has(compilationSuccess())
                 .has(linesCovered(4))
@@ -432,6 +442,7 @@ public class StandardResultWriterTest {
         String output = generatedResult();
 
         assertThat(output)
+                .has(versionInformation(versionInformation))
                 .has(finalGradeOnScreen(34))
                 .has(compilationSuccess())
                 .has(linesCovered(4))
@@ -459,6 +470,7 @@ public class StandardResultWriterTest {
         String output = generatedResult();
 
         assertThat(output)
+                .has(versionInformation(versionInformation))
                 .has(compilationSuccess())
                 .has(testResults())
                 .has(numberOfJUnitTestsPassing(3))
@@ -480,6 +492,7 @@ public class StandardResultWriterTest {
         String output = generatedResult();
 
         assertThat(output)
+                .has(versionInformation(versionInformation))
                 .has(compilationSuccess())
                 .has(testResults())
                 .has(numberOfJUnitTestsPassing(3))
@@ -506,6 +519,7 @@ public class StandardResultWriterTest {
         String output = generatedResult();
 
         assertThat(output)
+                .has(versionInformation(versionInformation))
                 .has(compilationSuccess())
                 .has(testResults())
                 .has(numberOfJUnitTestsPassing(1))
@@ -530,6 +544,7 @@ public class StandardResultWriterTest {
         String output = generatedResult();
 
         assertThat(output)
+                .has(versionInformation(versionInformation))
                 .has(compilationSuccess())
                 .has(testResults())
                 .has(noJUnitTestsFound())

--- a/src/test/java/unit/writer/standard/StandardResultWriterTest.java
+++ b/src/test/java/unit/writer/standard/StandardResultWriterTest.java
@@ -8,6 +8,7 @@ import nl.tudelft.cse1110.andy.result.*;
 import nl.tudelft.cse1110.andy.writer.ResultWriter;
 import nl.tudelft.cse1110.andy.writer.standard.RandomAsciiArtGenerator;
 import nl.tudelft.cse1110.andy.writer.standard.StandardResultWriter;
+import nl.tudelft.cse1110.andy.writer.standard.VersionInformation;
 import org.assertj.core.api.Condition;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -29,11 +30,12 @@ import static unit.writer.standard.StandardResultTestAssertions.*;
 
 public class StandardResultWriterTest {
     protected Context ctx = mock(Context.class);
+    protected VersionInformation versionInformation = new VersionInformation("testVersion", "testBuildTimestamp", "testCommitId");
     protected RandomAsciiArtGenerator asciiArtGenerator = mock(RandomAsciiArtGenerator.class);
     protected ResultWriter writer;
 
     protected ResultWriter buildWriter() {
-        return new StandardResultWriter(asciiArtGenerator);
+        return new StandardResultWriter(versionInformation, asciiArtGenerator);
     }
 
     @TempDir

--- a/src/test/java/unit/writer/weblab/WebLabResultWriterTest.java
+++ b/src/test/java/unit/writer/weblab/WebLabResultWriterTest.java
@@ -25,7 +25,7 @@ public class WebLabResultWriterTest extends StandardResultWriterTest {
 
     @Override
     protected ResultWriter buildWriter() {
-        return new WebLabResultWriter(asciiArtGenerator);
+        return new WebLabResultWriter(versionInformation, asciiArtGenerator);
     }
 
     private String highlightsJson() {


### PR DESCRIPTION
Added the Maven version, latest git commit and build timestamp in the output generated by StandardResultWriter. Added tests for the new behaviour.

This changed the parameters accepted by StandardResultWriter, so a modification in the Mojo is also necessary - https://github.com/cse1110/andy-maven-plugin/pull/4