### PR TITLE
Print explanation when test score is 0/100

### DIFF
--- a/src/main/java/nl/tudelft/cse1110/andy/execution/mode/ModeActionSelector.java
+++ b/src/main/java/nl/tudelft/cse1110/andy/execution/mode/ModeActionSelector.java
@@ -24,6 +24,10 @@ public class ModeActionSelector {
     }
 
     public Action getAction() {
+        if (this.action == META_TEST) {
+            throw new IllegalStateException("The META_TEST action should only be used in unit tests");
+        }
+
         return action;
     }
 

--- a/src/main/java/nl/tudelft/cse1110/andy/writer/standard/StandardResultWriter.java
+++ b/src/main/java/nl/tudelft/cse1110/andy/writer/standard/StandardResultWriter.java
@@ -1,6 +1,8 @@
 package nl.tudelft.cse1110.andy.writer.standard;
 
 import nl.tudelft.cse1110.andy.execution.Context;
+import nl.tudelft.cse1110.andy.execution.mode.Action;
+import nl.tudelft.cse1110.andy.execution.mode.Mode;
 import nl.tudelft.cse1110.andy.execution.mode.ModeActionSelector;
 import nl.tudelft.cse1110.andy.result.*;
 import nl.tudelft.cse1110.andy.utils.ExceptionUtils;
@@ -77,9 +79,11 @@ public class StandardResultWriter implements ResultWriter {
         // we only show grades in specific modes and actions
         // if ModeActionSelector is not injected yet (i.e., it's null), it's because compilation fail.
         // in this case, we give it a zero, no matter the mode.
-        boolean shouldShowGrades = modeActionSelector(ctx)!=null && modeActionSelector(ctx).shouldCalculateAndShowGrades();
-        if(!shouldShowGrades)
+        boolean shouldShowGrades = modeActionSelector(ctx) != null && modeActionSelector(ctx).shouldCalculateAndShowGrades();
+        if (!shouldShowGrades) {
+            printZeroGradeReason(ctx);
             return;
+        }
 
         int finalGrade = result.getFinalGrade();
 
@@ -104,6 +108,37 @@ public class StandardResultWriter implements ResultWriter {
             l("");
             l(randomAsciiArt);
         }
+    }
+
+    private void printZeroGradeReason(Context ctx) {
+        var mas = modeActionSelector(ctx);
+        if (mas == null) {
+            return;
+        }
+
+        StringBuilder reason = new StringBuilder();
+
+        reason.append("\nFinal test score is ");
+
+        if (mas.getMode() == Mode.EXAM) {
+            reason.append("shown as 0/100 during the exam and will be calculated after the exam is over.");
+        } else {
+            reason.append("0/100 ");
+            if (mas.getAction() != Action.FULL_WITH_HINTS && mas.getAction() != Action.FULL_WITHOUT_HINTS) {
+                reason.append("as you are only ");
+                if (mas.getAction() == Action.TESTS)
+                    reason.append("checking if your tests pass");
+                else if (mas.getAction() == Action.META_TEST)
+                    reason.append("checking what the meta test score is");
+                else if (mas.getAction() == Action.COVERAGE)
+                    reason.append("running code coverage");
+            }
+            reason.append(". ");
+
+            reason.append("To have your code graded, click on one of the buttons to assess your submission (with or without hints).");
+        }
+
+        l(reason.toString());
     }
 
     private void printGradeCalculationDetails(String what, int score, int total, double weight) {

--- a/src/main/java/nl/tudelft/cse1110/andy/writer/standard/StandardResultWriter.java
+++ b/src/main/java/nl/tudelft/cse1110/andy/writer/standard/StandardResultWriter.java
@@ -128,8 +128,6 @@ public class StandardResultWriter implements ResultWriter {
                 reason.append("as you are only ");
                 if (mas.getAction() == Action.TESTS)
                     reason.append("checking if your tests pass");
-                else if (mas.getAction() == Action.META_TEST)
-                    reason.append("checking what the meta test score is");
                 else if (mas.getAction() == Action.COVERAGE)
                     reason.append("running code coverage");
             }

--- a/src/test/java/unit/writer/standard/StandardResultTestAssertions.java
+++ b/src/test/java/unit/writer/standard/StandardResultTestAssertions.java
@@ -246,6 +246,10 @@ public class StandardResultTestAssertions {
         return not(containsRegex("--- Assessment"));
     }
 
+    public static Condition<String> zeroScoreExplanation() {
+        return containsRegex("Final test score is (shown as )?0/100");
+    }
+
     public static Condition<String> noJacocoCoverage() {
         return not(containsRegex("--- JaCoCo coverage"));
     }

--- a/src/test/java/unit/writer/standard/StandardResultWriterTest.java
+++ b/src/test/java/unit/writer/standard/StandardResultWriterTest.java
@@ -2,6 +2,7 @@ package unit.writer.standard;
 
 import nl.tudelft.cse1110.andy.config.DirectoryConfiguration;
 import nl.tudelft.cse1110.andy.execution.Context;
+import nl.tudelft.cse1110.andy.execution.mode.Action;
 import nl.tudelft.cse1110.andy.execution.mode.Mode;
 import nl.tudelft.cse1110.andy.execution.mode.ModeActionSelector;
 import nl.tudelft.cse1110.andy.result.*;
@@ -195,7 +196,8 @@ public class StandardResultWriterTest {
                 .has(fullGradeDescription("Meta tests", 2, 3, 0.25))
                 .has(mutationScore(5, 6))
                 .has(noMetaTests())
-                .has(noCodeChecks());
+                .has(noCodeChecks())
+                .has(not(zeroScoreExplanation()));
 
         verify(asciiArtGenerator, times(0)).getRandomAsciiArt();
     }
@@ -250,6 +252,7 @@ public class StandardResultWriterTest {
         when(modeActionSelector.shouldShowFullHints()).thenReturn(false);
         when(modeActionSelector.shouldShowPartialHints()).thenReturn(false);
         when(modeActionSelector.getMode()).thenReturn(Mode.PRACTICE);
+        when(modeActionSelector.getAction()).thenReturn(Action.TESTS);
 
         when(ctx.getModeActionSelector()).thenReturn(modeActionSelector);
 
@@ -287,7 +290,9 @@ public class StandardResultWriterTest {
                 .has(not(fullGradeDescription("Mutation coverage", 5, 6, 0.25)))
                 .has(not(fullGradeDescription("Code checks", 3, 4, 0.25)))
                 .has(not(fullGradeDescription("Meta tests", 2, 3, 0.25)))
-                .has(mutationScore(5, 6));
+                .has(mutationScore(5, 6))
+                .has(zeroScoreExplanation())
+                .contains("only checking if your tests pass");
 
         verify(asciiArtGenerator, times(0)).getRandomAsciiArt();
     }
@@ -321,7 +326,8 @@ public class StandardResultWriterTest {
                 .has(noJacocoCoverage())
                 .has(noCodeChecks())
                 .has(noMetaTests())
-                .has(noPitestCoverage());
+                .has(noPitestCoverage())
+                .has(not(zeroScoreExplanation()));
 
         verify(asciiArtGenerator, times(0)).getRandomAsciiArt();
     }
@@ -348,6 +354,7 @@ public class StandardResultWriterTest {
         assertThat(output)
                 .has(versionInformation(versionInformation))
                 .has(finalGradeOnScreen(100))
+                .has(not(zeroScoreExplanation()))
                 .contains("random ascii art");
     }
 
@@ -403,7 +410,8 @@ public class StandardResultWriterTest {
                 .has(mutationScore(5, 6))
                 .has(scoreOfCodeChecks(3, 4))
                 .has(metaTestsPassing(2))
-                .has(metaTests(3));
+                .has(metaTests(3))
+                .has(not(zeroScoreExplanation()));
 
         if (fullHints) {
             assertThat(output)
@@ -454,7 +462,8 @@ public class StandardResultWriterTest {
                 .has(fullGradeDescription("Meta tests", 0, 0, 0.25))
                 .has(mutationScore(5, 6))
                 .has(noCodeChecksToBeAssessed())
-                .has(metaTests(0));
+                .has(metaTests(0))
+                .has(not(zeroScoreExplanation()));
     }
 
     @Test


### PR DESCRIPTION
Print a suitable explanation to the output when the weblab score is overridden to 0/100 due to the selected mode or action