### PR TITLE
Add Action to SubmissionMetaData

### DIFF
--- a/src/main/java/nl/tudelft/cse1110/andy/writer/weblab/SubmissionMetaData.java
+++ b/src/main/java/nl/tudelft/cse1110/andy/writer/weblab/SubmissionMetaData.java
@@ -1,15 +1,19 @@
 package nl.tudelft.cse1110.andy.writer.weblab;
 
+import nl.tudelft.cse1110.andy.execution.mode.Action;
+
 public class SubmissionMetaData {
     private final String course;
     private final String studentId;
     private final String studentName;
     private final String exercise;
+    private final Action action;
 
-    public SubmissionMetaData(String course, String studentId, String studentName, String exercise) {
+    public SubmissionMetaData(String course, String studentId, String studentName, String exercise, Action action) {
         this.course = course;
         this.studentId = studentId;
         this.studentName = studentName;
         this.exercise = exercise;
+        this.action = action;
     }
 }

--- a/src/main/java/nl/tudelft/cse1110/andy/writer/weblab/WebLabResultWriter.java
+++ b/src/main/java/nl/tudelft/cse1110/andy/writer/weblab/WebLabResultWriter.java
@@ -98,7 +98,7 @@ public class WebLabResultWriter extends StandardResultWriter {
             return;
 
         Submission submission = new Submission(
-                new SubmissionMetaData("course", "studentid", "studentname", "exercise"),
+                new SubmissionMetaData("course", "studentid", "studentname", "exercise", ctx.getAction()),
                 result
         );
 


### PR DESCRIPTION
A nice-to-have analytics is seeing how many different types have been submitted per an exercise. In order to send this information to the analytics application, I added `Action` to `SubmissionMetaData`.