### PR TITLE
Improve SecurityException message

### DIFF
--- a/src/main/java/nl/tudelft/cse1110/andy/execution/security/AndySecurityManager.java
+++ b/src/main/java/nl/tudelft/cse1110/andy/execution/security/AndySecurityManager.java
@@ -53,10 +53,14 @@ public class AndySecurityManager extends SecurityManager {
 
         // If the currently requested permission should not be allowed,
         // throw an exception to block the execution
-        var ex = new SecurityException("Operation not permitted: " +
-                                       perm.getClass().getName() + " " +
-                                       perm.getName() + " " +
-                                       perm.getActions());
+        var ex = new SecurityException(
+                String.format("Operation not permitted: %s name=%s actions=%s mockito=%b jdk=%b",
+                        perm.getClass().getName(),
+                        perm.getName(),
+                        perm.getActions(),
+                        mockitoInternal,
+                        jdkInternalLoader
+                ));
 
         // Print the stack trace to make debugging easier
         ex.printStackTrace();

--- a/src/main/java/nl/tudelft/cse1110/andy/execution/security/AndySecurityManager.java
+++ b/src/main/java/nl/tudelft/cse1110/andy/execution/security/AndySecurityManager.java
@@ -53,7 +53,7 @@ public class AndySecurityManager extends SecurityManager {
 
         // If the currently requested permission should not be allowed,
         // throw an exception to block the execution
-        var ex = new SecurityException(
+        throw new SecurityException(
                 String.format("Operation not permitted: %s name=%s actions=%s mockito=%b jdk=%b",
                         perm.getClass().getName(),
                         perm.getName(),
@@ -61,11 +61,6 @@ public class AndySecurityManager extends SecurityManager {
                         mockitoInternal,
                         jdkInternalLoader
                 ));
-
-        // Print the stack trace to make debugging easier
-        ex.printStackTrace();
-
-        throw ex;
     }
 
     private boolean checkPermissionsUntrusted(Permission perm, boolean mockitoInternal, boolean jdkInternalLoader) {

--- a/src/test/java/integration/SecurityTest.java
+++ b/src/test/java/integration/SecurityTest.java
@@ -12,12 +12,12 @@ public class SecurityTest extends IntegrationTestBase {
 
     @ParameterizedTest
     @CsvSource({
-            "WriteResultsXml,results.xml write",
-            "SystemExit,exitVM.",
-            "SetProperty,test write",
-            "RuntimeExec,execute",
-            "ReadSource,ExploitTest.java read",
-            "ReadClass,ExploitTest$1.class read"
+            "WriteResultsXml,name=results.xml actions=write",
+            "SystemExit,name=exitVM.",
+            "SetProperty,test actions=write",
+            "RuntimeExec,actions=execute",
+            "ReadSource,ExploitTest.java actions=read",
+            "ReadClass,ExploitTest$1.class actions=read"
     })
     void securityTest(String exploitFile, String expectedMessage) {
         // Provide working directory path to user code for testing purposes


### PR DESCRIPTION
Improved the message thrown in the SecurityManager, and removed the line that prints the stacktrace every time a SecurityException is thrown, as it is no longer necessary.