### PR TITLE
Remove "getClass" from security keyword blacklist as it can cause false positives

### DIFF
--- a/src/main/java/nl/tudelft/cse1110/andy/execution/step/SourceCodeSecurityCheckStep.java
+++ b/src/main/java/nl/tudelft/cse1110/andy/execution/step/SourceCodeSecurityCheckStep.java
@@ -58,7 +58,6 @@ public class SourceCodeSecurityCheckStep implements ExecutionStep {
         var keywords = Map.of(
                 "Configuration", "Accessing the task configuration in your code is not allowed",
                 "forName", reflectionMsg,
-                "getClass", reflectionMsg,
                 "getDeclaredConstructor", reflectionMsg,
                 "getDeclaredMethods", reflectionMsg,
                 "getField", reflectionMsg,


### PR DESCRIPTION
`getClass()` is sometimes used in the `equals` methods of classes in order to compare their type. It can cause false positives, so I think it's best to remove it from the blacklist.