### PR TITLE
PIT not working with jqwik fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,13 @@
             <version>1.5.1</version>
         </dependency>
 
+        <dependency>
+            <groupId>net.jqwik</groupId>
+            <artifactId>jqwik-engine</artifactId>
+            <version>1.5.1</version>
+            <scope>compile</scope>
+        </dependency>
+
         <!-- https://mvnrepository.com/artifact/org.mockito/mockito-core -->
         <dependency>
             <groupId>org.mockito</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-java</artifactId>
-            <version>3.141.59</version>
+            <version>4.0.0</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-dependency-plugin -->

--- a/pom.xml
+++ b/pom.xml
@@ -338,7 +338,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.3.0</version>
                 <configuration>
                     <doclint>none</doclint>
                     <source>15</source>

--- a/pom.xml
+++ b/pom.xml
@@ -176,6 +176,11 @@
             <artifactId>selenium-java</artifactId>
             <version>4.0.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>htmlunit-driver</artifactId>
+            <version>3.55.0</version>
+        </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-dependency-plugin -->
         <dependency>

--- a/src/main/java/nl/tudelft/cse1110/andy/execution/ExecutionFlow.java
+++ b/src/main/java/nl/tudelft/cse1110/andy/execution/ExecutionFlow.java
@@ -56,9 +56,9 @@ public class ExecutionFlow {
 
     private List<ExecutionStep> basicSteps() {
         return Arrays.asList(
-                new SetSecurityManagerStep(),
+                //new SetSecurityManagerStep(),
                 new OrganizeSourceCodeStep(),
-                new SourceCodeSecurityCheckStep(),
+                //new SourceCodeSecurityCheckStep(),
                 new CompilationStep(),
                 new ReplaceClassloaderStep(),
                 new GetRunConfigurationStep());

--- a/src/main/java/nl/tudelft/cse1110/andy/execution/step/RunJUnitTestsStep.java
+++ b/src/main/java/nl/tudelft/cse1110/andy/execution/step/RunJUnitTestsStep.java
@@ -16,6 +16,7 @@ import org.junit.platform.launcher.listeners.TestExecutionSummary;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.util.List;
 
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
 
@@ -47,6 +48,15 @@ public class RunJUnitTestsStep implements ExecutionStep {
             launcher.execute(request);
 
             TestExecutionSummary summary = listener.getSummary();
+
+            /* Print all the exceptions that were occurred.
+               In most cases, these will be useless.
+               However this gives very valuable information with bugs like the Selenium bug.
+             */
+            for (int i = 0; i < summary.getFailures().size(); i++) {
+                console.println("\nFailure Report [" + (i + 1) + "/" + summary.getFailures().size() + "]");
+                summary.getFailures().get(i).getException().printStackTrace(console);
+            }
 
             /* Restore the sysout back, and put it in the result in case there's something */
             System.setOut(console);

--- a/src/main/java/nl/tudelft/cse1110/andy/execution/step/RunPitestStep.java
+++ b/src/main/java/nl/tudelft/cse1110/andy/execution/step/RunPitestStep.java
@@ -21,6 +21,8 @@ import org.apache.commons.io.FileUtils;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.PrintStream;
+import java.lang.management.ManagementFactory;
+import java.lang.management.RuntimeMXBean;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -45,12 +47,17 @@ public class RunPitestStep implements ExecutionStep {
             final ReportOptions data = pr.getOptions();
 
             // let's silence the sysout and java logging
-            PrintStream console = silencePitest();
+            //PrintStream console = silencePitest();
 
             // run!
+            RuntimeMXBean runtimeMXBean = ManagementFactory.getRuntimeMXBean();
+            for (String inputArgument : runtimeMXBean.getInputArguments()) {
+                System.out.println("Input " + inputArgument);
+            }
+            System.out.println(data);
             final CombinedStatistics stats = runReport(ctx, data, plugins);
 
-            System.setOut(console);
+            //System.setOut(console);
 
             extractAndRemoveReportFolder(outputPitestDir);
             result.logPitest(stats);
@@ -82,6 +89,10 @@ public class RunPitestStep implements ExecutionStep {
         args.add(dirCfg.getWorkingDir());
 
         args.add("--verbose");
+        args.add("true");
+
+        // Explicitly disable the classpath provided by Maven to be added.
+        args.add("--includeLaunchClasspath");
         args.add("false");
 
         args.add("--classPath");

--- a/src/main/java/nl/tudelft/cse1110/andy/execution/step/RunPitestStep.java
+++ b/src/main/java/nl/tudelft/cse1110/andy/execution/step/RunPitestStep.java
@@ -91,10 +91,6 @@ public class RunPitestStep implements ExecutionStep {
         args.add("--verbose");
         args.add("true");
 
-        // Explicitly disable the classpath provided by Maven to be added.
-        args.add("--includeLaunchClasspath");
-        args.add("false");
-
         args.add("--classPath");
         List<String> librariesToInclude = compiledClassesPlusLibraries(ctx, dirCfg);
         args.add(commaSeparated(librariesToInclude));

--- a/src/main/java/nl/tudelft/cse1110/andy/writer/standard/RandomAsciiArtGenerator.java
+++ b/src/main/java/nl/tudelft/cse1110/andy/writer/standard/RandomAsciiArtGenerator.java
@@ -16,16 +16,19 @@ public class RandomAsciiArtGenerator {
      */
     public String getRandomAsciiArt() {
         List<String> congratsFiles = listOfCongratsFiles();
+        try {
+            // Randomly pick one of the .txt files
+            Random random = new Random();
+            String randomAsciiFile = congratsFiles.get(random.nextInt(congratsFiles.size()));
 
-        // Randomly pick one of the .txt files
-        Random random = new Random();
-        String randomAsciiFile = congratsFiles.get(random.nextInt(congratsFiles.size()));
-
-        return readCongratsFile(randomAsciiFile);
+            return readCongratsFile(randomAsciiFile);
+        } catch (RuntimeException e) {
+            return "";
+        }
     }
 
 
-    private List<String> listOfCongratsFiles() {
+    private List<String> listOfCongratsFiles() throws RuntimeException {
         try {
             InputStream resourceAsStream = ResourceUtils.class.getResourceAsStream("/congrats/0list.txt");
             String list = IOUtils.toString(resourceAsStream, StandardCharsets.UTF_8);
@@ -42,7 +45,7 @@ public class RandomAsciiArtGenerator {
         }
     }
 
-    private String readCongratsFile(String randomAsciiFile) {
+    private String readCongratsFile(String randomAsciiFile) throws RuntimeException {
         try {
             InputStream resourceAsStream = ResourceUtils.class.getResourceAsStream("/congrats/" + randomAsciiFile);
             return IOUtils.toString(resourceAsStream, StandardCharsets.UTF_8);


### PR DESCRIPTION
**Note:** This relies on the changes made in the [Selenium fix](https://github.com/cse1110/andy/tree/fix/selenium) branch as the security manager goes ham with external assertions. Also, the print functionality of that branch was quite helpful.

**The actual fix:** Is contained in this commit 81c24ad95f561632313c201e18e3fddcd4872f9e, if applicable it can be cherry picked.

# What happened

For some reason, the test classes were picked up but the JUnit tests could not be read. After comparing the settings and classpaths of the version IntelliJ runs vs. the version that is run by Maven, I did a set difference. This showed that for some reason, the Maven version did not include `jqwik-engine-1.5.1.jar` in its classpath. 

Inspecting the Maven dependency structure of `andy`, it looked like this:
![img](https://i.imgur.com/jdVpOux.png)

The *(runtime)* explains why it was not included in the classpath. I'm not entirely sure but I think it's because the Maven plugin only includes dependencies that need to be compiled when the plugin is being run.

# The actual fix

Explicitly adding a dependency for the engine and setting its scope to `compile` overrides this *(runtime)* setting. 
