### PR TITLE
Add configuration options to skip Jacoco or Pitest

### DIFF
--- a/src/main/java/nl/tudelft/cse1110/andy/config/RunConfiguration.java
+++ b/src/main/java/nl/tudelft/cse1110/andy/config/RunConfiguration.java
@@ -61,6 +61,10 @@ public abstract class RunConfiguration {
         return null;
     }
 
+    public boolean skipJacoco() {
+        return false;
+    }
+
     public boolean skipPitest() {
         return false;
     }

--- a/src/main/java/nl/tudelft/cse1110/andy/config/RunConfiguration.java
+++ b/src/main/java/nl/tudelft/cse1110/andy/config/RunConfiguration.java
@@ -61,4 +61,8 @@ public abstract class RunConfiguration {
         return null;
     }
 
+    public boolean skipPitest() {
+        return false;
+    }
+
 }

--- a/src/main/java/nl/tudelft/cse1110/andy/execution/step/RunJacocoCoverageStep.java
+++ b/src/main/java/nl/tudelft/cse1110/andy/execution/step/RunJacocoCoverageStep.java
@@ -38,6 +38,12 @@ public class RunJacocoCoverageStep implements ExecutionStep {
 
     @Override
     public void execute(Context ctx, ResultBuilder result) {
+
+        // Skip step if disabled
+        if (ctx.getRunConfiguration().skipJacoco()) {
+            return;
+        }
+
         DirectoryConfiguration dirCfg = ctx.getDirectoryConfiguration();
         RunConfiguration runCfg = ctx.getRunConfiguration();
 

--- a/src/main/java/nl/tudelft/cse1110/andy/execution/step/RunPitestStep.java
+++ b/src/main/java/nl/tudelft/cse1110/andy/execution/step/RunPitestStep.java
@@ -33,6 +33,12 @@ public class RunPitestStep implements ExecutionStep {
 
     @Override
     public void execute(Context ctx, ResultBuilder result) {
+
+        // Skip step if disabled
+        if (ctx.getRunConfiguration().skipPitest()) {
+            return;
+        }
+
         final PluginServices plugins = PluginServices.makeForContextLoader();
         final OptionsParser parser = new OptionsParser(new PluginFilter(plugins));
 

--- a/src/test/java/integration/JacocoTest.java
+++ b/src/test/java/integration/JacocoTest.java
@@ -88,4 +88,19 @@ public class JacocoTest extends IntegrationTestBase {
         );
     }
 
+    @Test
+    void jacocoDisabled() {
+        Result result = run(Action.COVERAGE, "NumberUtilsAddLibrary", "NumberUtilsAddSmoke", "NumberUtilsJacocoSkipped");
+
+        assertThat(result.getCoverage().wasExecuted()).isFalse();
+
+        assertThat(result.getCoverage().getCoveredLines()).isZero();
+        assertThat(result.getCoverage().getCoveredInstructions()).isZero();
+        assertThat(result.getCoverage().getCoveredBranches()).isZero();
+
+        assertThat(result.getCoverage().getNotCoveredLines().isEmpty()).isTrue();
+        assertThat(result.getCoverage().getPartiallyCoveredLines().isEmpty()).isTrue();
+        assertThat(result.getCoverage().getFullyCoveredLines().isEmpty()).isTrue();
+    }
+
 }

--- a/src/test/java/integration/PitestTest.java
+++ b/src/test/java/integration/PitestTest.java
@@ -70,4 +70,18 @@ public class PitestTest extends IntegrationTestBase {
         assertThat(result.getMutationTesting().getTotalNumberOfMutants()).isEqualTo(10);
     }
 
+
+    /*
+     * Configuration is set to skip Pitest.
+     */
+    @Test
+    void pitestSkipped() {
+        // Pitest is skipped
+        Result result = run("ZagZigLibrary", "ZagZigAllMutantsKilled", "ZagZigPitestSkipped");
+
+        assertThat(result.getMutationTesting().wasExecuted()).isFalse();
+        assertThat(result.getMutationTesting().getKilledMutants()).isZero();
+        assertThat(result.getMutationTesting().getTotalNumberOfMutants()).isZero();
+    }
+
 }

--- a/src/test/resources/grader/fixtures/Config/NumberUtilsJacocoSkipped.java
+++ b/src/test/resources/grader/fixtures/Config/NumberUtilsJacocoSkipped.java
@@ -1,0 +1,32 @@
+package delft;
+
+import nl.tudelft.cse1110.andy.config.MetaTest;
+import nl.tudelft.cse1110.andy.config.RunConfiguration;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class Configuration extends RunConfiguration {
+
+    @Override
+    public Map<String, Float> weights() {
+        return new HashMap<>() {{
+            put("coverage", 1.0f);
+            put("mutation", 0.0f);
+            put("meta", 0.0f);
+            put("codechecks", 0.0f);
+        }};
+    }
+
+    @Override
+    public List<String> classesUnderTest() {
+        return List.of("delft.NumberUtils");
+    }
+
+    @Override
+    public boolean skipJacoco() {
+        return true;
+    }
+
+}

--- a/src/test/resources/grader/fixtures/Config/ZagZigPitestSkipped.java
+++ b/src/test/resources/grader/fixtures/Config/ZagZigPitestSkipped.java
@@ -1,0 +1,48 @@
+package delft;
+
+import nl.tudelft.cse1110.andy.codechecker.engine.CheckScript;
+import nl.tudelft.cse1110.andy.config.RunConfiguration;
+import nl.tudelft.cse1110.andy.config.MetaTest;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class Configuration extends RunConfiguration {
+
+    @Override
+    public CheckScript checkScript() {
+        return new CheckScript(List.of());
+    }
+
+    @Override
+    public Map<String, Float> weights() {
+        return new HashMap<>() {{
+            put("coverage", 0.0f);
+            put("mutation", 0.5f);
+            put("meta", 0.0f);
+            put("codechecks", 0.5f);
+        }};
+    }
+
+    @Override
+    public List<String> classesUnderTest() {
+        return List.of("delft.ZagZig");
+    }
+
+    @Override
+    public List<String> listOfMutants() {
+        return DEFAULTS;
+    }
+
+    @Override
+    public List<MetaTest> metaTests() {
+        return List.of();
+    }
+
+    @Override
+    public boolean skipPitest() {
+        return true;
+    }
+
+}


### PR DESCRIPTION
Added two methods in `RunConfiguration` - `skipJacoco()` and `skipPitest()`, which can be overriden in order to disable Pitest and Jacoco in exercises where it doesn't make sense to run them, such as exercises that rely on testing an external process.