### PR TITLE
Overload constructor

### DIFF
--- a/src/main/java/nl/tudelft/cse1110/andy/Andy.java
+++ b/src/main/java/nl/tudelft/cse1110/andy/Andy.java
@@ -33,8 +33,16 @@ public class Andy {
         this.metaData = metaData;
     }
 
+    public Andy(Action action, String workDir, String outputDir, List<String> librariesToBeIncluded, ResultWriter writer) {
+        this(action, workDir, outputDir, librariesToBeIncluded, writer, SubmissionMetaData.empty());
+    }
+
     public Andy(Action action, String workDir, String outputDir, ResultWriter writer, SubmissionMetaData metaData) {
         this(action, workDir, outputDir, null, writer, metaData);
+    }
+
+    public Andy(Action action, String workDir, String outputDir, ResultWriter writer) {
+        this(action, workDir, outputDir, null, writer);
     }
 
     public void run() {

--- a/src/main/java/nl/tudelft/cse1110/andy/writer/weblab/SubmissionMetaData.java
+++ b/src/main/java/nl/tudelft/cse1110/andy/writer/weblab/SubmissionMetaData.java
@@ -10,4 +10,8 @@ public class SubmissionMetaData {
         this.studentId = studentId;
         this.exercise = exercise;
     }
+
+    public static SubmissionMetaData empty() {
+        return new SubmissionMetaData(null, null, null);
+    }
 }


### PR DESCRIPTION
Overload the Andy constructor in order to preserve backward compatibility after the changes introduced in #70 as those changes break the Maven plugin

Fixes #83 