### PR TITLE
Fix meta test nonexistent replacement check

### DIFF
--- a/src/main/java/nl/tudelft/cse1110/andy/execution/metatest/library/evaluators/StringReplacementEvaluator.java
+++ b/src/main/java/nl/tudelft/cse1110/andy/execution/metatest/library/evaluators/StringReplacementEvaluator.java
@@ -16,7 +16,7 @@ public class StringReplacementEvaluator implements MetaEvaluator {
         String shiftedOldLibraryCode = oldLibraryCode.replaceAll("(?m)^\\s+", "");
         String replaced = shiftedOldLibraryCode.replace(shiftedOld, this.replacement);
 
-        if (replaced.equals(oldLibraryCode)) {
+        if (replaced.equals(shiftedOldLibraryCode)) {
             throw new RuntimeException("Meta test failed to find this text replacement:\n" + this.old);
         }
 

--- a/src/test/java/integration/LibraryMetaTestsTest.java
+++ b/src/test/java/integration/LibraryMetaTestsTest.java
@@ -1,5 +1,6 @@
 package integration;
 
+import nl.tudelft.cse1110.andy.execution.step.RunMetaTestsStep;
 import nl.tudelft.cse1110.andy.result.Result;
 import org.junit.jupiter.api.Test;
 
@@ -74,6 +75,17 @@ public class LibraryMetaTestsTest extends BaseMetaTestsTest {
                 .has(passedMetaTest("AlwaysReturnsNotFound"))
                 .has(passedMetaTest("AlwaysReturnsStartIndex"))
                 .has(passedMetaTest("DoesNotUseStartIndex"));
+    }
+
+    @Test
+    void metaTestInternalFailure() {
+        Result result = run("NumberUtilsAddLibrary", "NumberUtilsAddAllTestsPass", "NumberUtilsAddConfigurationWithMetaTestInternalFailure");
+
+        assertThat(result.hasGenericFailure()).isTrue();
+        assertThat(result.getGenericFailure().getStepName())
+                .isPresent()
+                .get()
+                .isEqualTo(RunMetaTestsStep.class.getSimpleName());
     }
 
 }

--- a/src/test/resources/grader/fixtures/Config/NumberUtilsAddConfigurationWithMetaTestInternalFailure.java
+++ b/src/test/resources/grader/fixtures/Config/NumberUtilsAddConfigurationWithMetaTestInternalFailure.java
@@ -1,0 +1,81 @@
+package delft;
+
+import nl.tudelft.cse1110.andy.config.RunConfiguration;
+import nl.tudelft.cse1110.andy.config.MetaTest;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class Configuration extends RunConfiguration {
+
+    @Override
+    public Map<String, Float> weights() {
+        return new HashMap<>() {{
+            put("coverage", 0.1f);
+            put("mutation", 0.3f);
+            put("meta", 0.4f);
+            put("codechecks", 0.2f);
+        }};
+    }
+
+    @Override
+    public List<String> classesUnderTest() {
+        return List.of("delft.NumberUtils");
+    }
+
+    @Override
+    public List<MetaTest> metaTests() {
+        return List.of(
+            MetaTest.withStringReplacement(3, "AppliesMultipleCarriesWrongly",
+                """
+                int sum = leftDigit + rightDigit + carry;
+
+                result.addFirst(sum % 10);
+                carry = sum / 10;
+                """,
+                """
+                int sum;
+
+                if (leftDigit + rightDigit >= 10) {
+                    sum = leftDigit + rightDigit;
+                    carry = 1;
+                }
+                else {
+                    sum = leftDigit + rightDigit + carry;
+                    carry = 0;
+                }
+                result.addFirst(sum % 10);
+                """),
+            MetaTest.withLineReplacement("DoesNotApplyCarryAtAll", 47, 68,
+                """
+                for (int i = 0; i < Math.max(reversedLeft.size(), reversedRight.size()); i++) {
+
+                    int leftDigit = reversedLeft.size() > i ? reversedLeft.get(i) : 0;
+                    int rightDigit = reversedRight.size() > i ? reversedRight.get(i) : 0;
+
+                    if (leftDigit < 0 || leftDigit > 9 || rightDigit < 0 || rightDigit > 9)
+                        throw new IllegalArgumentException();
+
+                    int sum = leftDigit + rightDigit;
+
+                    result.addFirst(sum % 10);
+                }
+
+                // remove leading zeroes from the result
+                while (result.size() > 1 && result.get(0) == 0)
+                    result.remove(0);
+
+                if (result.isEmpty()) {
+                    result.addFirst(0);
+                }
+
+                return result;
+                """),
+            MetaTest.withStringReplacement("BadMetaTest",
+                "something that doesn't exist",
+                    ""),
+            MetaTest.withLineReplacement(2, "DoesNotCheckNumbersOutOfRange", 52, 53, "")
+        );
+    }
+}


### PR DESCRIPTION
The check that ensures the code to be replaced is actually present in the library was wrong.