### PR TITLE
Update logger dependency and move from log4j to reload4j.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>1.7.30</version>
+            <version>1.7.35</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This will update the log4j dependency to avoid a remote code execution attack while grading. This internally replaces log4j with [reload4j](https://reload4j.qos.ch/) which is a drop-in by the guys who make Logback (my logger of choice). reload4j fixes security vulnerabilities on ancient versions of log4j such as ours, while Apache refuses to do so.

My tests were running a little flakey today, but I think that was due to my filesystem being bugged; I hope the pipeline passes.