### PR TITLE
Changes the README to uphold the sancity of human life

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,4 +77,8 @@ fabric.properties
 target/
 *.class
 
+# Emacs
+*~
+#*
+
 # End of https://www.gitignore.io/api/intellij

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Andy is a simple Java application. All it needs is:
 
 For TU Delft students, Andy can be used directly in WebLab, our cloud IDE.
 
-_We are working on a command-line tool that will make Andy easier to be executed_.
+_We are working on a command-line tool that will make Andy easier to run._
 
 ## Team
 


### PR DESCRIPTION
A small change to the README which replaces the word `execute` with `run` in order to avoid  potential confusion of whether the awkward connotation of summarily executing the current director of studies of the CSE bachelor. The change proposed still is relatively vague on what it does. However the potential implementation of the program would, in the worst case, help professor Zaidman with his cardio as opposed to starting an autonomous swarm of murder robots. 