### PR TITLE
Fix some AssertJ assertions not being recognised by code check

### DIFF
--- a/src/main/java/nl/tudelft/cse1110/andy/codechecker/checks/TestMethodsHaveAssertions.java
+++ b/src/main/java/nl/tudelft/cse1110/andy/codechecker/checks/TestMethodsHaveAssertions.java
@@ -39,6 +39,13 @@ public class TestMethodsHaveAssertions extends WithinTestMethod {
         // assertj
         add("assertThat");
         add("assertThatThrownBy");
+        add("assertThatExceptionOfType");
+        add("assertThatCode");
+        add("assertThatIllegalArgumentException");
+        add("assertThatIllegalStateException");
+        add("assertThatIOException");
+        add("assertThatNullPointerException");
+        add("assertThatObject");
 
     }};
 


### PR DESCRIPTION
Added more methods that can be used to write assertions with AssertJ to the `TestMethodsHaveAssertions` code check.

Closes #106 