### PR TITLE
Fix "no tests found" message being shown if generator method lookup fails

### DIFF
--- a/src/main/java/nl/tudelft/cse1110/andy/result/UnitTestsResult.java
+++ b/src/main/java/nl/tudelft/cse1110/andy/result/UnitTestsResult.java
@@ -72,6 +72,10 @@ public class UnitTestsResult {
         return testsRan == 0;
     }
 
+    public boolean noTestsFound() {
+        return getTestsFound() == 0 && !hasFailingMessage();
+    }
+
     @Override
     public String toString() {
         return "UnitTestsResult{" +

--- a/src/main/java/nl/tudelft/cse1110/andy/writer/standard/StandardResultWriter.java
+++ b/src/main/java/nl/tudelft/cse1110/andy/writer/standard/StandardResultWriter.java
@@ -286,7 +286,7 @@ public class StandardResultWriter implements ResultWriter {
             return;
 
         l("\n--- JUnit execution");
-        if (tests.getTestsFound() == 0 && !tests.hasFailingMessage()) {
+        if (tests.noTestsFound()) {
             noTestsFound(tests);
         } else {
             l(String.format("%d/%d passed", tests.getTestsSucceeded(), tests.getTestsFound()));

--- a/src/main/java/nl/tudelft/cse1110/andy/writer/standard/StandardResultWriter.java
+++ b/src/main/java/nl/tudelft/cse1110/andy/writer/standard/StandardResultWriter.java
@@ -286,7 +286,7 @@ public class StandardResultWriter implements ResultWriter {
             return;
 
         l("\n--- JUnit execution");
-        if (tests.getTestsFound() == 0) {
+        if (tests.getTestsFound() == 0 && !tests.hasFailingMessage()) {
             noTestsFound(tests);
         } else {
             l(String.format("%d/%d passed", tests.getTestsSucceeded(), tests.getTestsFound()));

--- a/src/test/java/unit/writer/standard/StandardResultWriterTest.java
+++ b/src/test/java/unit/writer/standard/StandardResultWriterTest.java
@@ -676,6 +676,29 @@ public class StandardResultWriterTest {
     }
 
     @Test
+    void testPrintTestResultsWithNoTestsFoundDueToTestFailure() {
+        Result result = new ResultTestDataBuilder()
+                .withTestResults(0, 0, 0,
+                        List.of(new TestFailureInfo("exampleTestCase", "example failure")),
+                        "")
+                .withCompilationFail()
+                .build();
+
+        writer.write(ctx, result);
+
+        String output = generatedResult();
+
+        assertThat(output)
+                .has(compilationSuccess())
+                .has(testResults())
+                .has(not(noJUnitTestsFound()))
+                .has(allTestsNeedToPassMessage())
+                .has(numberOfJUnitTestsPassing(0))
+                .has(totalNumberOfJUnitTests(0))
+                .contains("- exampleTestCase:\nexample failure");
+    }
+
+    @Test
     void uncaughtError() {
         Exception ex = new RuntimeException("Some exception");
 

--- a/src/test/resources/grader/fixtures/Solution/ArrayUtilsIsSortedWithGeneratorMethodError.java
+++ b/src/test/resources/grader/fixtures/Solution/ArrayUtilsIsSortedWithGeneratorMethodError.java
@@ -1,0 +1,36 @@
+package delft;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.*;
+import java.util.stream.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.*;
+import org.junit.jupiter.params.provider.*;
+
+class ArrayUtilsTest {
+
+    // In this example test class, the generator method is not static, causing an exce.
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("generator")
+    void isSorted(String description, int[] array, boolean expectedResult) {
+        assertThat(ArrayUtils.isSorted(array)).isEqualTo(expectedResult);
+    }
+
+    private Stream<Arguments> generator() {
+        Arguments tc0 = Arguments.of("empty", new int[]{}, true);
+        Arguments tc1 = Arguments.of("single element", new int[]{1}, true);
+        Arguments tc2 = Arguments.of("unsorted", new int[]{1, 3, 2}, false);
+        Arguments tc3 = Arguments.of("sorted", new int[]{1, 2, 3}, true);
+        Arguments tc4 = Arguments.of("null array", null, true);
+        return Stream.of(tc0, tc1, tc2, tc3, tc4);
+    }
+
+}
+
+
+
+
+


### PR DESCRIPTION
Instead of the "no tests found" message, the exception messages generated by JUnit or the tips from [JUnitUtils#simplifyTestErrorMessage](https://github.com/cse1110/andy/blob/71c986f0b05037696a8d605a1cb3131b079a7222/src/main/java/nl/tudelft/cse1110/andy/utils/JUnitUtils.java#L7) are shown when Andy finds no tests due to a reported test failure.

Fixes #117 