### PR TITLE
Add hint when Pitest fails due to flaky tests

### DIFF
--- a/src/main/java/nl/tudelft/cse1110/andy/execution/ExecutionFlow.java
+++ b/src/main/java/nl/tudelft/cse1110/andy/execution/ExecutionFlow.java
@@ -15,7 +15,7 @@ public class ExecutionFlow {
     private LinkedList<ExecutionStep> steps;
     private final ResultWriter writer;
 
-    private ExecutionFlow(Context ctx, ResultBuilder result, ResultWriter writer, List<ExecutionStep> steps) {
+    public ExecutionFlow(Context ctx, ResultBuilder result, ResultWriter writer, List<ExecutionStep> steps) {
         this.steps = new LinkedList<>();
 
         if (ctx.isSecurityEnabled()) {

--- a/src/main/java/nl/tudelft/cse1110/andy/execution/ExecutionFlow.java
+++ b/src/main/java/nl/tudelft/cse1110/andy/execution/ExecutionFlow.java
@@ -70,6 +70,7 @@ public class ExecutionFlow {
                 new SourceCodeSecurityCheckStep(),
                 new CompilationStep(),
                 new ReplaceClassloaderStep(),
-                new GetRunConfigurationStep());
+                new GetRunConfigurationStep(),
+                new InjectModeActionStepsStep());
     }
 }

--- a/src/main/java/nl/tudelft/cse1110/andy/execution/ExecutionFlow.java
+++ b/src/main/java/nl/tudelft/cse1110/andy/execution/ExecutionFlow.java
@@ -15,14 +15,14 @@ public class ExecutionFlow {
     private LinkedList<ExecutionStep> steps;
     private final ResultWriter writer;
 
-    private ExecutionFlow(Context ctx, ResultBuilder result, ResultWriter writer) {
+    private ExecutionFlow(Context ctx, ResultBuilder result, ResultWriter writer, List<ExecutionStep> steps) {
         this.steps = new LinkedList<>();
 
         if (ctx.isSecurityEnabled()) {
             this.steps.add(new SetSecurityManagerStep());
         }
 
-        steps.addAll(0, basicSteps());
+        this.steps.addAll(0, steps);
 
         this.writer = writer;
         this.ctx = ctx;
@@ -56,7 +56,7 @@ public class ExecutionFlow {
     }
 
     public static ExecutionFlow build(Context ctx, ResultBuilder result, ResultWriter writer) {
-        return new ExecutionFlow(ctx, result, writer);
+        return new ExecutionFlow(ctx, result, writer, basicSteps());
     }
 
     public static ExecutionFlow buildWithoutSecurityManager(Context ctx, ResultBuilder result, ResultWriter writer) {
@@ -64,7 +64,7 @@ public class ExecutionFlow {
         return ExecutionFlow.build(ctx, result, writer);
     }
 
-    private List<ExecutionStep> basicSteps() {
+    private static List<ExecutionStep> basicSteps() {
         return Arrays.asList(
                 new OrganizeSourceCodeStep(),
                 new SourceCodeSecurityCheckStep(),

--- a/src/main/java/nl/tudelft/cse1110/andy/execution/step/GetRunConfigurationStep.java
+++ b/src/main/java/nl/tudelft/cse1110/andy/execution/step/GetRunConfigurationStep.java
@@ -26,36 +26,13 @@ public class GetRunConfigurationStep implements ExecutionStep {
             RunConfiguration runConfiguration = (RunConfiguration) runConfigurationClass.getDeclaredConstructor().newInstance();
 
             ctx.setRunConfiguration(runConfiguration);
-
-            this.addExecutionSteps(ctx, result);
         } catch (NoSuchElementException ex) {
             // There's no configuration set. We put a default one!
             RunConfiguration runConfiguration = new DefaultRunConfiguration(allClassesButTestingAndConfigOnes(ctx.getNewClassNames()));
             ctx.setRunConfiguration(runConfiguration);
-
-            this.addExecutionSteps(ctx, result);
         } catch (Exception ex) {
             result.genericFailure(this, ex);
         }
-    }
-
-    private void addExecutionSteps(Context ctx, ResultBuilder result) {
-        ExecutionFlow flow = ctx.getFlow();
-
-        ModeActionSelector modeActionSelector = createModeSelector(ctx, result);
-        flow.addSteps(modeActionSelector.getSteps());
-    }
-
-    private ModeActionSelector createModeSelector(Context ctx, ResultBuilder result) {
-        RunConfiguration runConfiguration = ctx.getRunConfiguration();
-
-        Mode mode = runConfiguration.mode();
-        Action action = ctx.getAction();
-
-        ModeActionSelector modeActionSelector = new ModeActionSelector(mode, action);
-        ctx.setModeSelector(modeActionSelector);
-
-        return modeActionSelector;
     }
 
     @Override

--- a/src/main/java/nl/tudelft/cse1110/andy/execution/step/InjectModeActionStepsStep.java
+++ b/src/main/java/nl/tudelft/cse1110/andy/execution/step/InjectModeActionStepsStep.java
@@ -1,0 +1,31 @@
+package nl.tudelft.cse1110.andy.execution.step;
+
+import nl.tudelft.cse1110.andy.config.RunConfiguration;
+import nl.tudelft.cse1110.andy.execution.Context;
+import nl.tudelft.cse1110.andy.execution.ExecutionFlow;
+import nl.tudelft.cse1110.andy.execution.ExecutionStep;
+import nl.tudelft.cse1110.andy.execution.mode.Action;
+import nl.tudelft.cse1110.andy.execution.mode.Mode;
+import nl.tudelft.cse1110.andy.execution.mode.ModeActionSelector;
+import nl.tudelft.cse1110.andy.result.ResultBuilder;
+
+public class InjectModeActionStepsStep implements ExecutionStep {
+    @Override
+    public void execute(Context ctx, ResultBuilder result) {
+        ExecutionFlow flow = ctx.getFlow();
+        ModeActionSelector modeActionSelector = createModeSelector(ctx, result);
+        flow.addSteps(modeActionSelector.getSteps());
+    }
+
+    private ModeActionSelector createModeSelector(Context ctx, ResultBuilder result) {
+        RunConfiguration runConfiguration = ctx.getRunConfiguration();
+
+        Mode mode = runConfiguration.mode();
+        Action action = ctx.getAction();
+
+        ModeActionSelector modeActionSelector = new ModeActionSelector(mode, action);
+        ctx.setModeSelector(modeActionSelector);
+
+        return modeActionSelector;
+    }
+}

--- a/src/main/java/nl/tudelft/cse1110/andy/writer/standard/StandardResultWriter.java
+++ b/src/main/java/nl/tudelft/cse1110/andy/writer/standard/StandardResultWriter.java
@@ -95,17 +95,7 @@ public class StandardResultWriter implements ResultWriter {
                 toDisplay.append("---\n");
             }
 
-            Optional<Integer> externalProcessExitCode = result.getGenericFailure().getExternalProcessExitCode();
-            if (externalProcessExitCode.isPresent()) {
-                toDisplay.append(String.format("External process crashed with exit code %d.\n",
-                        externalProcessExitCode.get()));
-                Optional<String> externalProcessErrorMessages = result.getGenericFailure().getExternalProcessErrorMessages();
-                if (externalProcessErrorMessages.isPresent() &&
-                    !externalProcessErrorMessages.get().isEmpty()) {
-                    toDisplay.append(String.format("    Error message:\n%s\n",
-                            externalProcessErrorMessages.get()));
-                }
-            }
+            printExternalProcessFailure(result);
 
             result.getGenericFailure().getGenericFailureMessage().ifPresent(s -> toDisplay.append(s));
 
@@ -147,6 +137,20 @@ public class StandardResultWriter implements ResultWriter {
         }
 
         return Optional.empty();
+    }
+
+    private void printExternalProcessFailure(Result result) {
+        Optional<Integer> externalProcessExitCode = result.getGenericFailure().getExternalProcessExitCode();
+        if (externalProcessExitCode.isPresent()) {
+            toDisplay.append(String.format("External process crashed with exit code %d.\n",
+                    externalProcessExitCode.get()));
+            Optional<String> externalProcessErrorMessages = result.getGenericFailure().getExternalProcessErrorMessages();
+            if (externalProcessErrorMessages.isPresent() &&
+                !externalProcessErrorMessages.get().isEmpty()) {
+                toDisplay.append(String.format("    Error message:\n%s\n",
+                        externalProcessErrorMessages.get()));
+            }
+        }
     }
 
 

--- a/src/main/java/nl/tudelft/cse1110/andy/writer/standard/StandardResultWriter.java
+++ b/src/main/java/nl/tudelft/cse1110/andy/writer/standard/StandardResultWriter.java
@@ -78,20 +78,7 @@ public class StandardResultWriter implements ResultWriter {
         if (result.hasGenericFailure()) {
             Optional<String> exceptionMessage = result.getGenericFailure().getExceptionMessage();
 
-            boolean issueWithTests = false;
-
-            if (exceptionMessage.isPresent()) {
-                Optional<String> hint = getGenericFailureHint(exceptionMessage.get());
-                if (hint.isPresent()) {
-                    issueWithTests = true;
-
-                    toDisplay.append("An error occurred while running your tests.\n\n---\n\n");
-
-                    toDisplay.append(hint.get()).append("\n\n---\n\n");
-
-                    toDisplay.append("Full details:\n\n");
-                }
-            }
+            boolean issueWithTests = checkForIssueWithTests(exceptionMessage);
 
             if (!issueWithTests) {
                 toDisplay.append("Oh, we are facing a failure that we cannot recover from.\n");
@@ -126,6 +113,24 @@ public class StandardResultWriter implements ResultWriter {
         }
 
         return false;
+    }
+
+    private boolean checkForIssueWithTests(Optional<String> exceptionMessage) {
+        boolean issueWithTests = false;
+
+        if (exceptionMessage.isPresent()) {
+            Optional<String> hint = getGenericFailureHint(exceptionMessage.get());
+            if (hint.isPresent()) {
+                issueWithTests = true;
+
+                toDisplay.append("An error occurred while running your tests.\n\n---\n\n");
+
+                toDisplay.append(hint.get()).append("\n\n---\n\n");
+
+                toDisplay.append("Full details:\n\n");
+            }
+        }
+        return issueWithTests;
     }
 
     /**

--- a/src/test/java/integration/GenericFailureWithHintTest.java
+++ b/src/test/java/integration/GenericFailureWithHintTest.java
@@ -1,0 +1,66 @@
+package integration;
+
+import nl.tudelft.cse1110.andy.config.DirectoryConfiguration;
+import nl.tudelft.cse1110.andy.execution.Context;
+import nl.tudelft.cse1110.andy.execution.ExecutionFlow;
+import nl.tudelft.cse1110.andy.execution.ExecutionStep;
+import nl.tudelft.cse1110.andy.execution.mode.Action;
+import nl.tudelft.cse1110.andy.result.Result;
+import nl.tudelft.cse1110.andy.result.ResultBuilder;
+import nl.tudelft.cse1110.andy.writer.standard.RandomAsciiArtGenerator;
+import nl.tudelft.cse1110.andy.writer.standard.StandardResultWriter;
+import nl.tudelft.cse1110.andy.writer.standard.VersionInformation;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.List;
+
+import static nl.tudelft.cse1110.andy.utils.FilesUtils.concatenateDirectories;
+import static nl.tudelft.cse1110.andy.utils.FilesUtils.readFile;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.not;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static unit.writer.standard.StandardResultTestAssertions.*;
+
+public class GenericFailureWithHintTest extends IntegrationTestBase {
+
+    @Override
+    protected void addSteps(ExecutionFlow flow) {
+        ExecutionStep badStep = mock(ExecutionStep.class);
+
+        doThrow(new org.pitest.help.PitHelpError(org.pitest.help.Help.FAILING_TESTS, 5))
+                .when(badStep).execute(any(Context.class), any(ResultBuilder.class));
+
+        flow.addSteps(List.of(badStep));
+    }
+
+    @Test
+    void genericFailureWithHint() {
+        // Arrange
+        Context ctx = mock(Context.class);
+        DirectoryConfiguration dirs = new DirectoryConfiguration("any", reportDir.toString());
+        when(ctx.getDirectoryConfiguration()).thenReturn(dirs);
+        StandardResultWriter writer = new StandardResultWriter(
+                new VersionInformation("testVersion", "testBuildTimestamp", "testCommitId"),
+                mock(RandomAsciiArtGenerator.class));
+
+        // Act
+        Result result = run(Action.TESTS, "NumberUtilsAddLibrary", "NumberUtilsAddAllTestsPass");
+
+        writer.write(ctx, result);
+
+        // Assert
+        assertThat(result.hasGenericFailure()).isTrue();
+
+        String output = readFile(new File(concatenateDirectories(reportDir.toString(), "stdout.txt")));
+
+        assertThat(output)
+                .has(not(compilationSuccess()))
+                .has(not(testResults()))
+                .has(not(genericFailure("")))
+                .contains("org.pitest.help.PitHelpError")
+                .contains("tests did not pass without mutation")
+                .contains("It appears that your test suite is flaky.");
+    }
+}

--- a/src/test/java/integration/GenericFailureWithStandardResultWriterTest.java
+++ b/src/test/java/integration/GenericFailureWithStandardResultWriterTest.java
@@ -82,7 +82,7 @@ public class GenericFailureWithStandardResultWriterTest extends IntegrationTestB
                 .has(not(genericFailure("")))
                 .contains("org.pitest.help.PitHelpError")
                 .contains("tests did not pass without mutation")
-                .contains("It appears that your test suite is flaky.");
+                .has(flakyTestSuiteMessage());
     }
 
     @Test
@@ -110,6 +110,6 @@ public class GenericFailureWithStandardResultWriterTest extends IntegrationTestB
                 .has(not(compilationSuccess()))
                 .has(not(testResults()))
                 .has(genericFailure("java.lang.RuntimeException: This is a very bad and scary exception"))
-                .doesNotContain("It appears that your test suite is flaky.");
+                .has(not(flakyTestSuiteMessage()));
     }
 }

--- a/src/test/java/integration/GenericFailureWithStandardResultWriterTest.java
+++ b/src/test/java/integration/GenericFailureWithStandardResultWriterTest.java
@@ -2,9 +2,9 @@ package integration;
 
 import nl.tudelft.cse1110.andy.config.DirectoryConfiguration;
 import nl.tudelft.cse1110.andy.execution.Context;
-import nl.tudelft.cse1110.andy.execution.ExecutionFlow;
 import nl.tudelft.cse1110.andy.execution.ExecutionStep;
 import nl.tudelft.cse1110.andy.execution.mode.Action;
+import nl.tudelft.cse1110.andy.execution.step.*;
 import nl.tudelft.cse1110.andy.result.Result;
 import nl.tudelft.cse1110.andy.result.ResultBuilder;
 import nl.tudelft.cse1110.andy.writer.ResultWriter;
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
-import java.util.List;
+import java.util.Arrays;
 
 import static nl.tudelft.cse1110.andy.utils.FilesUtils.concatenateDirectories;
 import static nl.tudelft.cse1110.andy.utils.FilesUtils.readFile;
@@ -55,19 +55,20 @@ public class GenericFailureWithStandardResultWriterTest extends IntegrationTestB
         writer.write(ctx, result);
     }
 
-    @Override
-    protected void addSteps(ExecutionFlow flow) {
+    @Test
+    void genericFailureWithHint() {
         ExecutionStep badStep = mock(ExecutionStep.class);
-
         doThrow(new org.pitest.help.PitHelpError(org.pitest.help.Help.FAILING_TESTS, 5))
                 .when(badStep).execute(any(Context.class), any(ResultBuilder.class));
 
-        flow.addSteps(List.of(badStep));
-    }
-
-    @Test
-    void genericFailureWithHint() {
-        Result result = run(Action.TESTS, "NumberUtilsAddLibrary", "NumberUtilsAddAllTestsPass");
+        Result result = run(Action.TESTS, "NumberUtilsAddLibrary", "NumberUtilsAddAllTestsPass",
+                Arrays.asList(
+                        new OrganizeSourceCodeStep(),
+                        new SourceCodeSecurityCheckStep(),
+                        new CompilationStep(),
+                        new ReplaceClassloaderStep(),
+                        new GetRunConfigurationStep(),
+                        badStep));
 
         writeResult(result);
 

--- a/src/test/java/integration/GenericFailureWithStandardResultWriterTest.java
+++ b/src/test/java/integration/GenericFailureWithStandardResultWriterTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.Arrays;
+import java.util.List;
 
 import static nl.tudelft.cse1110.andy.utils.FilesUtils.concatenateDirectories;
 import static nl.tudelft.cse1110.andy.utils.FilesUtils.readFile;
@@ -62,14 +63,7 @@ public class GenericFailureWithStandardResultWriterTest extends IntegrationTestB
                 .when(badStep).execute(any(Context.class), any(ResultBuilder.class));
 
         Result result = run(Action.TESTS, "NumberUtilsAddLibrary", "NumberUtilsAddAllTestsPass",
-                Arrays.asList(
-                        new OrganizeSourceCodeStep(),
-                        new SourceCodeSecurityCheckStep(),
-                        new CompilationStep(),
-                        new ReplaceClassloaderStep(),
-                        new GetRunConfigurationStep(),
-                        badStep,
-                        new InjectModeActionStepsStep()));
+                createSteps(badStep));
 
         writeResult(result);
 
@@ -92,14 +86,7 @@ public class GenericFailureWithStandardResultWriterTest extends IntegrationTestB
                 .when(badStep).execute(any(Context.class), any(ResultBuilder.class));
 
         Result result = run(Action.TESTS, "NumberUtilsAddLibrary", "NumberUtilsAddAllTestsPass",
-                Arrays.asList(
-                        new OrganizeSourceCodeStep(),
-                        new SourceCodeSecurityCheckStep(),
-                        new CompilationStep(),
-                        new ReplaceClassloaderStep(),
-                        new GetRunConfigurationStep(),
-                        badStep,
-                        new InjectModeActionStepsStep()));
+                createSteps(badStep));
 
         writeResult(result);
 
@@ -111,5 +98,16 @@ public class GenericFailureWithStandardResultWriterTest extends IntegrationTestB
                 .has(not(testResults()))
                 .has(genericFailure("java.lang.RuntimeException: This is a very bad and scary exception"))
                 .has(not(flakyTestSuiteMessage()));
+    }
+
+    private List<ExecutionStep> createSteps(ExecutionStep badStep) {
+        return Arrays.asList(
+                new OrganizeSourceCodeStep(),
+                new SourceCodeSecurityCheckStep(),
+                new CompilationStep(),
+                new ReplaceClassloaderStep(),
+                new GetRunConfigurationStep(),
+                badStep,
+                new InjectModeActionStepsStep());
     }
 }

--- a/src/test/java/integration/GenericFailureWithStandardResultWriterTest.java
+++ b/src/test/java/integration/GenericFailureWithStandardResultWriterTest.java
@@ -68,7 +68,8 @@ public class GenericFailureWithStandardResultWriterTest extends IntegrationTestB
                         new CompilationStep(),
                         new ReplaceClassloaderStep(),
                         new GetRunConfigurationStep(),
-                        badStep));
+                        badStep,
+                        new InjectModeActionStepsStep()));
 
         writeResult(result);
 

--- a/src/test/java/integration/IntegrationTestBase.java
+++ b/src/test/java/integration/IntegrationTestBase.java
@@ -4,6 +4,7 @@ import com.google.common.io.Files;
 import nl.tudelft.cse1110.andy.config.DirectoryConfiguration;
 import nl.tudelft.cse1110.andy.execution.Context;
 import nl.tudelft.cse1110.andy.execution.ExecutionFlow;
+import nl.tudelft.cse1110.andy.execution.ExecutionStep;
 import nl.tudelft.cse1110.andy.execution.mode.Action;
 import nl.tudelft.cse1110.andy.grade.GradeCalculator;
 import nl.tudelft.cse1110.andy.result.Result;
@@ -16,6 +17,7 @@ import org.junit.jupiter.api.AfterEach;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
 
 import static nl.tudelft.cse1110.andy.utils.ResourceUtils.resourceFolder;
 
@@ -34,7 +36,8 @@ public abstract class IntegrationTestBase {
     public Result run(Action action,
                       String libraryFile,
                       String solutionFile,
-                      String configurationFile) {
+                      String configurationFile,
+                      List<ExecutionStep> executionStepsOverride) {
         if (configurationFile != null) {
             copyConfigurationFile(configurationFile);
         }
@@ -56,7 +59,9 @@ public abstract class IntegrationTestBase {
 
         try {
             ResultWriter writer = getWriter();
-            ExecutionFlow flow = ExecutionFlow.build(ctx, resultBuilder, writer);
+            ExecutionFlow flow = executionStepsOverride == null ?
+                    ExecutionFlow.build(ctx, resultBuilder, writer) :
+                    new ExecutionFlow(ctx, resultBuilder, writer, executionStepsOverride);
 
             addSteps(flow);
 
@@ -70,12 +75,24 @@ public abstract class IntegrationTestBase {
         return resultBuilder.build();
     }
 
+    public Result run(Action action,
+                      String libraryFile,
+                      String solutionFile,
+                      String configurationFile) {
+        return run(action, libraryFile, solutionFile, configurationFile, null);
+    }
+
     protected ResultWriter getWriter() {
         return new EmptyWriter();
     }
 
     public Result run(Action action, String libraryFile, String solutionFile) {
-        return this.run(action, libraryFile, solutionFile, null);
+        return this.run(action, libraryFile, solutionFile, (String) null);
+    }
+
+    public Result run(Action action, String libraryFile, String solutionFile,
+                      List<ExecutionStep> executionStepsOverride) {
+        return this.run(action, libraryFile, solutionFile, null, executionStepsOverride);
     }
 
     public Result run(String libraryFile, String solutionFile, String configurationFile) {

--- a/src/test/java/unit/writer/standard/StandardResultTestAssertions.java
+++ b/src/test/java/unit/writer/standard/StandardResultTestAssertions.java
@@ -276,5 +276,14 @@ public class StandardResultTestAssertions {
         };
     }
 
+    public static Condition<String> flakyTestSuiteMessage() {
+        return new Condition<>() {
+            @Override
+            public boolean matches(String value) {
+                return value.contains("It appears that your test suite is flaky.");
+            }
+        };
+    }
+
 }
 


### PR DESCRIPTION
A hint is now shown if Pitest fails because the student's tests are flaky:

```
Andy v0.29-SNAPSHOT-9b2519a (2022-08-29T23:03:10+0200)

An error occurred while running your tests.

---

It appears that your test suite is flaky. Make sure that your tests do not randomly fail for no reason.

---

Full details:

The failure occurred in RunPitestStep
---
org.pitest.help.PitHelpError: 1 tests did not pass without mutation when calculating line coverage. Mutation testing requires a green suite.
See http://pitest.org for more details.
	at org.pitest.coverage.execute.DefaultCoverageGenerator.verifyBuildSuitableForMutationTesting(DefaultCoverageGenerator.java:115)
	at org.pitest.coverage.execute.DefaultCoverageGenerator.calculateCoverage(DefaultCoverageGenerator.java:97)
[...]
```

Perhaps there's a similar error which might occur in JaCoCo (I think I've seen an error like this before, but I couldn't replicate it now; if it exists, it appears to be a lot rarer).

Closes #115