### PR TITLE
Fix record classes resulting in an exception

### DIFF
--- a/.github/workflows/assignments_test.yml
+++ b/.github/workflows/assignments_test.yml
@@ -7,10 +7,10 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v2
-      - name: Set up JDK 15
+      - name: Set up JDK 17
         uses: actions/setup-java@v1
         with:
-          java-version: 15
+          java-version: 17
       - name: Setup python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/assignments_test_maven.yml
+++ b/.github/workflows/assignments_test_maven.yml
@@ -7,10 +7,10 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v2
-      - name: Set up JDK 15
+      - name: Set up JDK 17
         uses: actions/setup-java@v1
         with:
-          java-version: 15
+          java-version: 17
       - name: Setup python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,10 +6,10 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v2
-      - name: Set up JDK 15
+      - name: Set up JDK 17
         uses: actions/setup-java@v1
         with:
-          java-version: 15
+          java-version: 17
       - name: Cache Maven packages
         uses: actions/cache@v2
         with:

--- a/.github/workflows/weblab-tests.yml
+++ b/.github/workflows/weblab-tests.yml
@@ -9,10 +9,10 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v2
-      - name: Set up JDK 15
+      - name: Set up JDK 17
         uses: actions/setup-java@v1
         with:
-          java-version: 15
+          java-version: 17
       - name: Cache Maven packages
         uses: actions/cache@v2
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,8 @@
     <description>Andy, a tool that assesses your test suites</description>
 
     <properties>
-        <maven.compiler.source>15</maven.compiler.source>
-        <maven.compiler.target>15</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF8</project.build.sourceEncoding>
     </properties>
 
@@ -272,8 +272,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>15</source>
-                    <target>15</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
 
@@ -352,7 +352,7 @@
                 <version>3.3.1</version>
                 <configuration>
                     <doclint>none</doclint>
-                    <source>15</source>
+                    <source>17</source>
                 </configuration>
                 <executions>
                     <execution>

--- a/src/main/java/nl/tudelft/cse1110/andy/codechecker/engine/CheckScript.java
+++ b/src/main/java/nl/tudelft/cse1110/andy/codechecker/engine/CheckScript.java
@@ -44,7 +44,7 @@ public class CheckScript {
         parser.setBindingsRecovery(true);
 
         Map<String, String> options = JavaCore.getOptions();
-        JavaCore.setComplianceOptions(JavaCore.VERSION_15, options);
+        JavaCore.setComplianceOptions(JavaCore.VERSION_17, options);
         parser.setCompilerOptions(options);
 
         parser.setEnvironment(new String[0], new String[0], null, true);

--- a/src/main/java/nl/tudelft/cse1110/andy/execution/step/CompilationStep.java
+++ b/src/main/java/nl/tudelft/cse1110/andy/execution/step/CompilationStep.java
@@ -13,7 +13,7 @@ import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
-import javax.lang.model.util.ElementScanner9;
+import javax.lang.model.util.ElementScanner14;
 import javax.tools.*;
 import java.io.File;
 import java.util.*;
@@ -78,7 +78,7 @@ public class CompilationStep implements ExecutionStep {
         }
     }
 
-    @SupportedSourceVersion(SourceVersion.RELEASE_11)
+    @SupportedSourceVersion(SourceVersion.RELEASE_14)
     @SupportedAnnotationTypes("*")
     public class ClassNameProcessor extends AbstractProcessor {
         private final ClassNameScanner scanner;
@@ -100,7 +100,7 @@ public class CompilationStep implements ExecutionStep {
         }
     }
 
-    public class ClassNameScanner extends ElementScanner9< Void, Void > {
+    public class ClassNameScanner extends ElementScanner14< Void, Void > {
         private List<String> fullClassNames = new ArrayList<>();
 
         public Void visitType(final TypeElement type, final Void p) {

--- a/src/test/java/integration/JUnitTestsTest.java
+++ b/src/test/java/integration/JUnitTestsTest.java
@@ -199,6 +199,17 @@ public class JUnitTestsTest {
 
 
         @Test
+        void testParameterizedTestsWithJavaRecordClass() {
+            Result result = run(Action.TESTS, "ArrayUtilsIndexOfLibrary", "ArrayUtilsIndexOfJqwikWithParameterizedWithRecord");
+
+            assertThat(result.getTests())
+                    .has(failingTest("testNoElementInWholeArray"))
+                    .has(failingTest("testValueInArrayUniqueElements"))
+                    .has(failingParameterizedTest("test", 6));
+        }
+
+
+        @Test
         void testMessageOtherThanAssertionError() {
             Result result = run(Action.TESTS, "NumberUtilsAddPositiveLibrary", "NumberUtilsAddPositiveJqwikException");
 

--- a/src/test/java/unit/codechecker/JDTParser.java
+++ b/src/test/java/unit/codechecker/JDTParser.java
@@ -17,7 +17,7 @@ public class JDTParser {
         parser.setBindingsRecovery(true);
 
         Map<String, String> options = JavaCore.getOptions();
-        JavaCore.setComplianceOptions(JavaCore.VERSION_15, options);
+        JavaCore.setComplianceOptions(JavaCore.VERSION_17, options);
         parser.setCompilerOptions(options);
 
         parser.setEnvironment(new String[0], new String[0], null, true);

--- a/src/test/resources/grader/fixtures/Solution/ArrayUtilsIndexOfJqwikWithParameterizedWithRecord.java
+++ b/src/test/resources/grader/fixtures/Solution/ArrayUtilsIndexOfJqwikWithParameterizedWithRecord.java
@@ -1,0 +1,100 @@
+package delft;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.*;
+import java.util.stream.*;
+import net.jqwik.api.*;
+import net.jqwik.api.arbitraries.*;
+import net.jqwik.api.constraints.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.*;
+import org.junit.jupiter.params.provider.*;
+
+class ArrayUtilsTests {
+
+    record InputClass(
+        int index,
+        int start
+    ){}
+
+    /** Use this method to convert a list of integers to an array */
+    private int[] convertListToArray(List<Integer> numbers) {
+        int[] array = numbers.stream().mapToInt(x -> x).toArray();
+        return array;
+    }
+
+    //test when the element specified is certainly not in the array
+    @Property
+    void testNoElementInWholeArray(
+            @ForAll @Size(value=10) List<@IntRange(min = -1000, max = 1000) Integer> numbers,
+            @ForAll("inexistentElement") int valueToFind) {
+
+        int[] arr = convertListToArray(numbers);
+        assertEquals(2, ArrayUtils.indexOf(arr, valueToFind, 0));
+    }
+
+    //test when the element is in the array after or at start, unique elements only
+    @Property
+    void testValueInArrayUniqueElements(@ForAll @Size(value=10)
+                                                List<@IntRange Integer> numbers,
+                                        @ForAll("indexes") InputClass input) {
+        int index = input.index;
+        int start = input.start;
+        int[] arr = convertListToArray(numbers);
+        assertEquals(index, ArrayUtils.indexOf(arr, numbers.get(index), start));
+    }
+
+    @Provide
+    private Arbitrary<Integer> inexistentElement() {
+        return Arbitraries.oneOf(
+                Arbitraries.integers().lessOrEqual(-1001),
+                Arbitraries.integers().greaterOrEqual(1001)
+        );
+    }
+
+    @Provide
+    private Arbitrary<InputClass> indexes() {
+        IntegerArbitrary index = Arbitraries.integers().between(0, 9);
+        IntegerArbitrary start = Arbitraries.integers().between(0, 9);
+
+        return Combinators.combine(index, start).as(InputClass::new)
+                .filter(i -> i.index >= i.start);
+    }
+
+    @ParameterizedTest
+    @MethodSource("generator")
+    void test(int[] arr, int valueToFind, int startIndex, int expected) {
+        assertEquals(expected, ArrayUtils.indexOf(arr, valueToFind, startIndex));
+    }
+
+    static Stream<Arguments> generator() {
+        return Stream.of(
+                //test null
+                Arguments.of(null, 0, 0, -1),
+
+                //test negative startIndex
+                Arguments.of(new int[]{8, 1, 9, 2, 8, 1}, 9, -5, 2),
+
+                //test start index larger than array
+                Arguments.of(new int[]{5, 1}, 1, 5, -1),
+
+                //test value is in the array but not in the part specified by startIndex
+                Arguments.of(new int[]{2, 3, 4, 5}, 2, 1, -1),
+
+                //test value is in whole array non-unique elements
+                Arguments.of(new int[]{2, 3, 4, 2, 4, 5}, 2, 0, 0),
+
+                //test value is in array after start, non-unique elements
+                Arguments.of(new int[]{2, 3, 4, 3, 4, 5}, 2, 1, 3),
+
+                //test value is exactly at startIndex, non-unique elements (boundary)
+                Arguments.of(new int[]{5, 1, 6, 6, 1}, 1, 1, 1),
+
+                //test value is exactly at the end (boundary)
+                Arguments.of(new int[]{5, 1, 6}, 6, 0, 2)
+        );
+    }
+}
+


### PR DESCRIPTION
Parts of the compilation were done with old Java 9 components. This caused issues when newer syntax is used.

Fixes #116 