### PR TITLE
Fix issue with test discovery and add a system test for an SQL exercise

### DIFF
--- a/scripts/assignments_test.py
+++ b/scripts/assignments_test.py
@@ -47,7 +47,8 @@ for category_dir in get_directories(home_dir):
         with open(f'{os.environ["OUTPUT_DIR"]}/stdout.txt') as file:
             # Get the score from the `stdout.txt` file.
             file_content = file.read()
-            score = int(re.search('Final grade: [0-9]+', file_content).group().split()[2])
+            re_score = re.search('Final grade: [0-9]+', file_content)
+            score = int(re_score.group().split()[2]) if re_score else -1
 
             # Print the score for the assignment.
             print(f'{assignment_dir.split("/")[-2]}/{assignment_dir.split("/")[-1]}: {score}/100')

--- a/src/main/java/nl/tudelft/cse1110/andy/utils/ClassUtils.java
+++ b/src/main/java/nl/tudelft/cse1110/andy/utils/ClassUtils.java
@@ -69,7 +69,7 @@ public class ClassUtils {
 
         if (matchingClassNames.size() != 1) {
             throw new IllegalArgumentException(
-                    String.format("There are %d classes containing the substring \"Test\": %s." +
+                    String.format("There are %d classes containing the substring \"Test\": %s. " +
                                   "There must be only one such class, otherwise test class discovery is not possible.",
                             matchingClassNames.size(),
                             matchingClassNames)

--- a/src/main/java/nl/tudelft/cse1110/andy/utils/ClassUtils.java
+++ b/src/main/java/nl/tudelft/cse1110/andy/utils/ClassUtils.java
@@ -64,7 +64,8 @@ public class ClassUtils {
      * @throws IllegalArgumentException if there is not exactly 1 test class
      */
     public static String getTestClass(List<String> listOfClasses) {
-        List<String> matchingClassNames = listOfClasses.stream().filter(c -> c.contains("Test"))
+        List<String> matchingClassNames = listOfClasses.stream()
+                .filter(c -> c.substring(c.lastIndexOf(".")).contains("Test"))
                 .collect(Collectors.toList());
 
         if (matchingClassNames.size() != 1) {

--- a/src/main/java/nl/tudelft/cse1110/andy/utils/ClassUtils.java
+++ b/src/main/java/nl/tudelft/cse1110/andy/utils/ClassUtils.java
@@ -61,14 +61,22 @@ public class ClassUtils {
      *
      * @param listOfClasses the list of classes to find the test class
      * @return the name of the test class
-     * @throws NoSuchElementException if there are no test classes
+     * @throws IllegalArgumentException if there is not exactly 1 test class
      */
     public static String getTestClass(List<String> listOfClasses) {
-        String className = listOfClasses.stream().filter(c -> c.contains("Test"))
-                    .findFirst()
-                    .get();
+        List<String> matchingClassNames = listOfClasses.stream().filter(c -> c.contains("Test"))
+                .collect(Collectors.toList());
 
-        return className;
+        if (matchingClassNames.size() != 1) {
+            throw new IllegalArgumentException(
+                    String.format("There are %d classes containing the substring \"Test\": %s." +
+                                  "There must be only one such class, otherwise test class discovery is not possible.",
+                            matchingClassNames.size(),
+                            matchingClassNames)
+            );
+        }
+
+        return matchingClassNames.get(0);
     }
 
     /**Finds the configuration class.

--- a/src/test/java/integration/JUnitTestsTest.java
+++ b/src/test/java/integration/JUnitTestsTest.java
@@ -371,6 +371,18 @@ public class JUnitTestsTest {
             assertThat(result.getTests().hasTestsFailingOrFailures()).isFalse();
         }
 
+        // Multiple class names contain the substring "Test" -> test discovery fails
+        @Test
+        void multipleTestClassesDiscovered() {
+            Result result = run(Action.TESTS, "LibraryWithBadTestTemplate", "SolutionWithBadInheritance");
+
+            assertThat(result.hasFailed()).isTrue();
+            assertThat(result.hasGenericFailure()).isTrue();
+            assertThat(result.getGenericFailure().getExceptionMessage())
+                    .hasValueSatisfying(containsString(
+                            "java.lang.IllegalArgumentException: There are 2 classes containing the substring \"Test\""));
+        }
+
     }
 
     private static Condition<UnitTestsResult> failingTest(String nameOfTheTest) {

--- a/src/test/java/integration/JUnitTestsTest.java
+++ b/src/test/java/integration/JUnitTestsTest.java
@@ -226,6 +226,20 @@ public class JUnitTestsTest {
 
 
     @Nested
+    class SQLTests extends IntegrationTestBase {
+
+        @Test
+        void sqlTest() {
+            Result result = run(Action.TESTS, "RestaurantsLibrary", "RestaurantsOfficialSolution", "RestaurantsConfiguration");
+
+            assertThat(result.getTests().getTestsSucceeded()).isEqualTo(3);
+            assertThat(result.getTests().getTestsRan()).isEqualTo(3);
+            assertThat(result.getTests().hasTestsFailingOrFailures()).isFalse();
+        }
+    }
+
+
+    @Nested
     class GeneralMistakes extends IntegrationTestBase {
 
         // @BeforeAll methods should be static -> no tests detected

--- a/src/test/java/integration/JUnitTestsTest.java
+++ b/src/test/java/integration/JUnitTestsTest.java
@@ -384,7 +384,7 @@ public class JUnitTestsTest {
 
         // Multiple class names contain the substring "Test" -> test discovery fails
         @Test
-        void multipleTestClassesDiscovered() {
+        void multipleTestClassesDiscoveredShouldThrowException() {
             Result result = run(Action.TESTS, "LibraryWithBadTestTemplate", "SolutionWithBadInheritance");
 
             assertThat(result.hasFailed()).isTrue();

--- a/src/test/resources/grader/fixtures/Config/RestaurantsConfiguration.java
+++ b/src/test/resources/grader/fixtures/Config/RestaurantsConfiguration.java
@@ -1,0 +1,75 @@
+package delft;
+
+import nl.tudelft.cse1110.andy.config.MetaTest;
+import nl.tudelft.cse1110.andy.config.RunConfiguration;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class Configuration extends RunConfiguration {
+
+    @Override
+    public Map<String, Float> weights() {
+        return new HashMap<>() {{
+            put("coverage", 0.0f);
+            put("mutation", 0.0f);
+            put("meta", 1.0f);
+            put("codechecks", 0.0f);
+        }};
+    }
+
+    @Override
+    public List<String> classesUnderTest() {
+        return List.of("delft.RestaurantDao");
+    }
+
+    @Override
+    public List<MetaTest> metaTests() {
+        return List.of(
+                MetaTest.withStringReplacement("Change first boundary",
+                        "\"select name from restaurant where rating > 6.5 and rating <= 8 group by name order by name\"",
+                        "\"select name from restaurant where rating >= 6.5 and rating <= 8 group by name order by name\""
+                ),
+                MetaTest.withStringReplacement("Change second boundary",
+                        "\"select name from restaurant where rating > 6.5 and rating <= 8 group by name order by name\"",
+                        "\"select name from restaurant where rating > 6.5 and rating < 8 group by name order by name\""
+                ),
+                MetaTest.withStringReplacement("Change boundaries",
+                        "\"select name from restaurant where rating > 6.5 and rating <= 8 group by name order by name\"",
+                        "\"select name from restaurant where rating >= 6.5 and rating < 8 group by name order by name\""
+                ),
+                MetaTest.withStringReplacement("Change boundaries",
+                        "\"select name from restaurant where rating > 6.5 and rating <= 8 group by name order by name\"",
+                        "\"select name from restaurant where rating == 6.5 and rating < 8 group by name order by name\""
+                ),
+                MetaTest.withStringReplacement("Change boundaries",
+                        "\"select name from restaurant where rating > 6.5 and rating <= 8 group by name order by name\"",
+                        "\"select name from restaurant where rating > 6.5 group by name order by name\""
+                ),
+                MetaTest.withStringReplacement("Change boundaries",
+                        "\"select name from restaurant where rating > 6.5 and rating <= 8 group by name order by name\"",
+                        "\"select name from restaurant where rating <= 8 group by name order by name\""
+                ),
+                MetaTest.withStringReplacement("Change boundaries",
+                        "\"select name from restaurant where rating > 6.5 and rating <= 8 group by name order by name\"",
+                        "\"select name from restaurant where rating > 6.5 or rating <= 8 group by name order by name\""
+                ),
+                MetaTest.withStringReplacement("Order should be ASC",
+                        "\"select name from restaurant where rating > 6.5 and rating <= 8 group by name order by name\"",
+                        "\"select name from restaurant where rating > 6.5 and rating <= 8 group by name order by name desc\""
+                )
+        );
+    }
+
+    @Override
+    public boolean skipJacoco() {
+        return true;
+    }
+
+    @Override
+    public boolean skipPitest() {
+        return true;
+    }
+
+}

--- a/src/test/resources/grader/fixtures/Library/LibraryWithBadTestTemplate.java
+++ b/src/test/resources/grader/fixtures/Library/LibraryWithBadTestTemplate.java
@@ -1,0 +1,10 @@
+package delft;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import org.junit.jupiter.api.*;
+
+abstract class BadInheritanceTestTemplate {
+
+}

--- a/src/test/resources/grader/fixtures/Library/RestaurantsLibrary.java
+++ b/src/test/resources/grader/fixtures/Library/RestaurantsLibrary.java
@@ -342,7 +342,7 @@ class RestaurantDao {
     }
 }
 
-class RestaurantDaoIntegrationTest {
+class RestaurantDaoTemplate {
 
     protected static final String DB_CONNECTION = "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1";
     protected static final String DB_USER = "";

--- a/src/test/resources/grader/fixtures/Library/RestaurantsLibrary.java
+++ b/src/test/resources/grader/fixtures/Library/RestaurantsLibrary.java
@@ -1,0 +1,396 @@
+package delft;
+
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import org.junit.jupiter.api.*;
+
+class Employee {
+
+    private final long id;
+    private final String name;
+    private final String job;
+    private final int wage;
+    private final int age;
+    private final String restaurantName;
+
+    public Employee(long id, String name, String job, int wage, int age, String restaurantName) {
+        this.id = id;
+        this.name = name;
+        this.job = job;
+        this.wage = wage;
+        this.age = age;
+        this.restaurantName = restaurantName;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Employee)) {
+            return false;
+        }
+        Employee employee = (Employee) o;
+        return getId() == employee.getId() && getWage() == employee.getWage() &&
+               getAge() == employee.getAge() &&
+               getRestaurantName().equals(employee.getRestaurantName()) &&
+               getName().equals(employee.getName()) &&
+               getJob().equals(employee.getJob());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getId(), getName(), getJob(), getWage(), getAge(), getRestaurantName());
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getJob() {
+        return job;
+    }
+
+    public int getWage() {
+        return wage;
+    }
+
+    public int getAge() {
+        return age;
+    }
+
+    public String getRestaurantName() {
+        return restaurantName;
+    }
+
+}
+
+class EmployeeDao {
+
+    private final Connection connection;
+
+    public EmployeeDao(Connection connection) {
+        this.connection = connection;
+    }
+
+    public List<Employee> all() {
+        try {
+            PreparedStatement ps = connection.prepareStatement("select * from employee");
+
+            ResultSet rs = ps.executeQuery();
+
+            List<Employee> allEmployees = new ArrayList<>();
+            while (rs.next()) {
+                allEmployees.add(new Employee(rs.getLong("id"), rs.getString("name"),
+                        rs.getString("job"), rs.getInt("wage"), rs.getInt("age"),
+                        rs.getString("restaurant_name")));
+            }
+
+            return allEmployees;
+
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void save(Employee employee) throws SQLException {
+        try {
+            PreparedStatement ps = connection.prepareStatement(
+                    "insert into employee (id, name, job, wage, age, restaurant_name) values (?,?,?,?,?,?)");
+            ps.setLong(1, employee.getId());
+            ps.setString(2, employee.getName());
+            ps.setInt(3, employee.getWage());
+            ps.setInt(4, employee.getAge());
+            ps.setString(5, employee.getRestaurantName());
+            ps.execute();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}
+
+class Recipe {
+    private final String name;
+    private final int prepTime;
+    private final boolean vegan;
+    private final boolean desert;
+    private final int price;
+    private final long id;
+
+    public Recipe(long id, int prepTime, int price, boolean vegan, boolean desert, String name) {
+        this.id = id;
+        this.name = name;
+        this.prepTime = prepTime;
+        this.price = price;
+        this.vegan = vegan;
+        this.desert = desert;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Recipe recipe = (Recipe) o;
+        return id == recipe.getId() && prepTime == recipe.prepTime && price == recipe.price &&
+               vegan == recipe.vegan && desert == recipe.desert &&
+               name.equals(recipe.name);
+    }
+
+    @Override
+    public String toString() {
+        return "Recipe{" +
+               "name='" + name + '\'' +
+               ", preparation time=" + prepTime + '\'' +
+               ", price='" + price + '\'' +
+               ", is vegan='" + vegan + '\'' +
+               ", is desert='" + desert + '\'' +
+               '}';
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public int getPrepTime() {
+        return prepTime;
+    }
+
+    public int getPrice() {
+        return price;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public boolean getVegan() {
+        return vegan;
+    }
+
+    public boolean getDesert() {
+        return desert;
+    }
+}
+
+class RecipeDao {
+
+    private final Connection connection;
+
+    public RecipeDao(Connection connection) {
+        this.connection = connection;
+    }
+
+    public List<Recipe> all() {
+        try {
+            PreparedStatement ps = connection.prepareStatement("select * from recipe");
+            ResultSet rs = ps.executeQuery();
+            List<Recipe> allRecipes = new ArrayList<>();
+            while (rs.next()) {
+                allRecipes.add(new Recipe(rs.getLong("id"), rs.getInt("prepTime"),
+                        rs.getInt("price"),
+                        rs.getBoolean("vegan"), rs.getBoolean("dessert"),
+                        rs.getString("name")));
+            }
+            return allRecipes;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void save(Recipe recipe) {
+        try {
+            PreparedStatement ps = connection.prepareStatement(
+                    "insert into recipe (id, name, prepTime, vegan, desert, price) values (?,?,?,?,?,?)");
+            ps.setLong(1, recipe.getId());
+            ps.setString(2, recipe.getName());
+            ps.setInt(3, recipe.getPrepTime());
+            ps.setBoolean(4, recipe.getVegan());
+            ps.setBoolean(5, recipe.getDesert());
+            ps.setInt(6, recipe.getPrice());
+            ps.execute();
+            connection.commit();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}
+
+class Restaurant {
+    private final long id;
+    private final String name;
+    private final String cuisine;
+    private final double rating;
+    private final String location;
+
+    public Restaurant(long id, String name, String cuisine, double rating, String location) {
+        this.id = id;
+        this.name = name;
+        this.cuisine = cuisine;
+        this.rating = rating;
+        this.location = location;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Restaurant restaurant = (Restaurant) o;
+        return id == restaurant.getId() && rating == restaurant.rating &&
+               name.equals(restaurant.name) &&
+               cuisine.equals(restaurant.cuisine) &&
+               location.equals(restaurant.location);
+    }
+
+    @Override
+    public String toString() {
+        return "Restaurant{" +
+               "name='" + name + '\'' +
+               ", cuisine=" + cuisine + '\'' +
+               ", rating='" + rating + '\'' +
+               ", location='" + location + '\'' +
+               '}';
+    }
+
+    public double getRating() {
+        return rating;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getCuisine() {
+        return cuisine;
+    }
+
+    public String getLocation() {
+        return location;
+    }
+}
+
+class RestaurantDao {
+
+    private final Connection connection;
+
+    public RestaurantDao(Connection connection) {
+        this.connection = connection;
+    }
+
+    public List<Restaurant> all() {
+        try {
+            PreparedStatement ps = connection.prepareStatement("select * from restaurant");
+            ResultSet rs = ps.executeQuery();
+            List<Restaurant> allRestaurants = new ArrayList<>();
+            while (rs.next()) {
+                allRestaurants.add(
+                        new Restaurant(rs.getLong("id"), rs.getString("name"), rs.getString("cuisine"),
+                                rs.getDouble("rating"), rs.getString("location")));
+            }
+            return allRestaurants;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public List<String> getAverageRestaurant() {
+        try {
+            PreparedStatement ps = connection.prepareStatement(
+                    "select name from restaurant where rating > 6.5 and rating <= 8 group by name order by name");
+            ResultSet rs = ps.executeQuery();
+            List<String> allRestaurants = new ArrayList<>();
+            while (rs.next()) {
+                allRestaurants.add(rs.getString("name"));
+            }
+            return allRestaurants;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void save(Restaurant restaurant) {
+        try {
+            PreparedStatement ps = connection.prepareStatement(
+                    "insert into restaurant (id, name, cuisine, rating, location) values (?,?,?,?,?)");
+            ps.setLong(1, restaurant.getId());
+            ps.setString(2, restaurant.getName());
+            ps.setString(3, restaurant.getCuisine());
+            ps.setDouble(4, restaurant.getRating());
+            ps.setString(5, restaurant.getLocation());
+            ps.execute();
+            connection.commit();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}
+
+class RestaurantDaoIntegrationTest {
+
+    protected static final String DB_CONNECTION = "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1";
+    protected static final String DB_USER = "";
+    protected static final String DB_PASSWORD = "";
+
+    protected EmployeeDao employeeDao;
+    protected RestaurantDao restaurantDao;
+    protected RecipeDao recipeDao;
+
+    protected Connection connection;
+
+    private static void createTable(String createQuery, Connection connection) throws SQLException {
+        PreparedStatement createPreparedStatement = connection.prepareStatement(createQuery);
+        createPreparedStatement.execute();
+        connection.commit();
+    }
+
+
+    @BeforeEach
+    void openConnectionAndCleanup() throws SQLException {
+        try {
+            Class.forName("org.h2.Driver");
+        } catch (ClassNotFoundException e) {
+            System.out.println(e);
+        }
+        connection = DriverManager.getConnection(DB_CONNECTION, DB_USER, DB_PASSWORD);
+
+        createTable(
+                "create table if not exists restaurant (id int primary key, name varchar(255), " +
+                "cuisine varchar(255), rating float, location varchar(255))", connection);
+        createTable(
+                "create table if not exists employee (id int primary key, name varchar(255), " +
+                "job varchar(255), wage int, age int, restaurant_name varchar(255))", connection);
+        createTable(
+                "create table if not exists recipe (id int primary key, name varchar(255), " +
+                "prep_time int, vegan bool, desert bool, price int)", connection);
+        employeeDao = new EmployeeDao(connection);
+        restaurantDao = new RestaurantDao(connection);
+        recipeDao = new RecipeDao(connection);
+
+        connection.prepareStatement("truncate table restaurant").execute();
+        connection.prepareStatement("truncate table employee").execute();
+        connection.prepareStatement("truncate table recipe").execute();
+    }
+
+    @AfterEach
+    void close() throws SQLException {
+        connection.close();
+    }
+
+}

--- a/src/test/resources/grader/fixtures/Solution/RestaurantsOfficialSolution.java
+++ b/src/test/resources/grader/fixtures/Solution/RestaurantsOfficialSolution.java
@@ -1,0 +1,45 @@
+package delft;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.*;
+import java.util.stream.*;
+import java.sql.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.*;
+import org.junit.jupiter.params.provider.*;
+
+class SolutionTest extends RestaurantDaoIntegrationTest {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("getAverageGenerator")
+    public void getAverageRestaurantTest(String description, List<Restaurant> restaurants,
+                                         List<String> expectedOutput) {
+        for (Restaurant r : restaurants) {
+            restaurantDao.save(r);
+        }
+        List<String> output = restaurantDao.getAverageRestaurant();
+        String[] expected = new String[expectedOutput.size()];
+        expectedOutput.toArray(expected);
+        assertThat(output).containsExactly(expected);
+    }
+
+    public static Stream<Arguments> getAverageGenerator() {
+        String cuisineType = "type";
+        String location = "location";
+        Arguments tc1 = Arguments.of("2 ratings out of bounds, one within second boundary", List.of(
+                new Restaurant(1, "Pizzas!", cuisineType, 10.0, location),
+                new Restaurant(2, "Burgers", cuisineType, 5.9, location),
+                new Restaurant(3, "Seafood", cuisineType, 8.0, location)), List.of("Seafood"));
+        Arguments tc2 = Arguments.of("2 ratings out of bounds, one within first boundary", List.of(
+                new Restaurant(1, "Pizzas!", cuisineType, 10.0, location),
+                new Restaurant(2, "Burgers", cuisineType, 6.5, location),
+                new Restaurant(3, "Seafood", cuisineType, 6.6, location)), List.of("Seafood"));
+        Arguments tc3 = Arguments.of("1 ratings out of bounds, two within boundaries", List.of(
+                new Restaurant(1, "Pizzas!", cuisineType, 7.9, location),
+                new Restaurant(2, "Burgers", cuisineType, 6.5, location),
+                new Restaurant(3, "Seafood", cuisineType, 6.6, location)), List.of("Pizzas!", "Seafood"));
+
+        return Stream.of(tc1, tc2, tc3);
+    }
+}

--- a/src/test/resources/grader/fixtures/Solution/RestaurantsOfficialSolution.java
+++ b/src/test/resources/grader/fixtures/Solution/RestaurantsOfficialSolution.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.*;
 import org.junit.jupiter.params.provider.*;
 
-class SolutionTest extends RestaurantDaoIntegrationTest {
+class SolutionTest extends RestaurantDaoTemplate {
     @ParameterizedTest(name = "{0}")
     @MethodSource("getAverageGenerator")
     public void getAverageRestaurantTest(String description, List<Restaurant> restaurants,

--- a/src/test/resources/grader/fixtures/Solution/SolutionWithBadInheritance.java
+++ b/src/test/resources/grader/fixtures/Solution/SolutionWithBadInheritance.java
@@ -1,0 +1,17 @@
+package delft;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.*;
+import java.util.stream.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.*;
+import org.junit.jupiter.params.provider.*;
+
+class SolutionTest extends BadInheritanceTestTemplate {
+    @Test
+    public void getAverageRestaurantTest() {
+        assertThat(true).isTrue();
+    }
+}


### PR DESCRIPTION
Added this test in an attempt to reproduce #114 

The issue with SQL tests is that there is a test template class in the library (which contains SQL-related test setup code). This class is the parent class of the student's actual test class.

This parent class also matched the rules for test class discovery - its name contained the substring `Test`. As Andy does not expect that, it picks an arbitrary class matching that condition, meaning that on each execution either the actual test class or this dummy class containing no test methods will randomly be picked to be run, leading to the observed flakiness.

I fixed that by renaming the template class and adding a check to Andy to throw an exception if multiple matching classes are found, instead of simply picking one to make sure this does not happen in the future.

Closes #114 