### PR TITLE
Include jacoco coverage annotation by default

### DIFF
--- a/src/main/java/delft/GeneratedExcludeFromJacoco.java
+++ b/src/main/java/delft/GeneratedExcludeFromJacoco.java
@@ -1,0 +1,13 @@
+package delft;
+
+import java.lang.annotation.*;
+
+/**
+ * This annotation can be used to exclude classes and methods
+ * from code coverage calculation.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+public @interface GeneratedExcludeFromJacoco {
+}

--- a/src/test/java/integration/JacocoTest.java
+++ b/src/test/java/integration/JacocoTest.java
@@ -119,4 +119,18 @@ public class JacocoTest extends IntegrationTestBase {
         assertThat(result.getCodeChecks().getNumberOfPassedChecks()).isEqualTo(1);
         assertThat(result.getWeights().getCodeChecksWeight()).isNotZero();
     }
+
+    @Test
+    void excludedMethodsAreNotCounted() {
+        Result result = run(Action.FULL_WITH_HINTS, "AutoAssignerLibrary", "AutoAssignerOfficialSolution", "AutoAssignerConfiguration");
+
+        assertThat(result.getCoverage().wasExecuted()).isTrue();
+
+        assertThat(result.getCoverage().getCoveredLines()).isEqualTo(30);
+        assertThat(result.getCoverage().getTotalNumberOfLines()).isEqualTo(30);
+        assertThat(result.getCoverage().getCoveredInstructions()).isEqualTo(121);
+        assertThat(result.getCoverage().getTotalNumberOfInstructions()).isEqualTo(121);
+        assertThat(result.getCoverage().getCoveredBranches()).isEqualTo(10);
+        assertThat(result.getCoverage().getTotalNumberOfBranches()).isEqualTo(10);
+    }
 }

--- a/src/test/resources/grader/fixtures/Config/AutoAssignerConfiguration.java
+++ b/src/test/resources/grader/fixtures/Config/AutoAssignerConfiguration.java
@@ -1,0 +1,76 @@
+package delft;
+
+import nl.tudelft.cse1110.andy.codechecker.checks.*;
+import nl.tudelft.cse1110.andy.codechecker.engine.CheckScript;
+import nl.tudelft.cse1110.andy.codechecker.engine.SingleCheck;
+import nl.tudelft.cse1110.andy.config.MetaTest;
+import nl.tudelft.cse1110.andy.config.RunConfiguration;
+import nl.tudelft.cse1110.andy.execution.mode.Mode;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class Configuration extends RunConfiguration {
+
+    @Override
+    public Mode mode() {
+        return Mode.PRACTICE;
+    }
+
+    public int numberOfMutationsToConsider() {
+        return 15;
+    }    
+
+    @Override
+    public Map<String, Float> weights() {
+        return new HashMap<>() {{
+            put("coverage", 0.2f);
+            put("mutation", 0.2f);
+            put("meta", 0.6f);
+            put("codechecks", 0f);
+        }};
+    }
+
+    @Override
+    public List<String> classesUnderTest() {
+        return List.of("delft.AutoAssigner", "delft.Workshop");
+    }
+
+    @Override
+    public List<MetaTest> metaTests() {
+        return List.of(
+            MetaTest.withStringReplacement(
+                "check that number of spots goes down",
+                "spotsPerDate.put(date, spotsPerDate.get(date) - 1);",
+                "spotsPerDate.put(date, spotsPerDate.get(date));"
+            ),
+            MetaTest.withStringReplacement(
+                "checks different dates",
+                ".findFirst()",
+                ".skip(1).findFirst()"
+            ),
+            MetaTest.withStringReplacement(
+                "tries date with single spot",
+                "public boolean hasAvailableDate() {",
+                "public boolean hasAvailableDate() { if(spotsPerDate.values().stream().anyMatch(v -> v == 1)) throw new RuntimeException();"
+            ),
+            MetaTest.withStringReplacement(
+                "all assignments failed",
+                "return assignments;",
+                "if(!assignments.getErrors().isEmpty() && assignments.getAssignments().isEmpty()) throw new RuntimeException(); return assignments;"
+            ),
+            MetaTest.withStringReplacement(
+                "check the failed assignments in Assignments",
+                "assignments.noAvailableSpots(workshop, student);",
+                ""
+            ),
+            MetaTest.withStringReplacement(
+                "check assignments in Assignments",
+                "assignments.assign(workshop, student, nextDate);",
+                ""
+            )
+        );
+    }
+
+}

--- a/src/test/resources/grader/fixtures/Library/AutoAssignerLibrary.java
+++ b/src/test/resources/grader/fixtures/Library/AutoAssignerLibrary.java
@@ -1,0 +1,196 @@
+package delft;
+
+import java.util.*;
+import java.time.*;
+import java.time.format.*;
+
+class Student {
+    private final int id;
+    private final String name;
+    private final String email;
+
+    public Student(int id, String name, String email) {
+        this.id = id;
+        this.name = name;
+        this.email = email;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public String getEmail() {
+        return this.email;
+    }
+
+    @GeneratedExcludeFromJacoco
+    public int getId() {
+        return this.id;
+    }
+
+    @Override
+    @GeneratedExcludeFromJacoco
+    public int hashCode() {
+        return Objects.hash(this.id, this.name, this.email);
+    }
+
+    @Override
+    @GeneratedExcludeFromJacoco
+    public boolean equals(Object o) {
+        // self check
+        if (this == o)
+            return true;
+        // null check
+        if (o == null)
+            return false;
+        // type check and cast
+        if (getClass() != o.getClass())
+            return false;
+        Student other = (Student) o;
+        // field comparison
+        return Objects.equals(id, other.id)
+                && Objects.equals(name, other.name)
+                && Objects.equals(email, other.email);
+    }
+}
+
+class Workshop {
+    private final int id;
+    private final String name;
+    private final Map<ZonedDateTime, Integer> spotsPerDate;
+
+    public Workshop(int id, String name, Map<ZonedDateTime, Integer> spotsPerDate) {
+        this.id = id;
+        this.name = name;
+        this.spotsPerDate = new HashMap<ZonedDateTime, Integer>(spotsPerDate);
+    }
+
+    @GeneratedExcludeFromJacoco
+    public Map<ZonedDateTime, Integer> getSpotsPerDate() {
+        return new HashMap<ZonedDateTime, Integer>(this.spotsPerDate);
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    @GeneratedExcludeFromJacoco
+    public int getId() {
+        return this.id;
+    }
+
+    public boolean hasAvailableDate() {
+        // If any date has more than zero spots, this means there's an available date
+        return spotsPerDate.values().stream().anyMatch(v -> v > 0);
+    }
+
+    // If there's an available date, it returns this date.
+    // This method should not be called if there's no spot available.
+    public ZonedDateTime getNextAvailableDate() {
+        // picks the first one that has available spots
+        ZonedDateTime firstAvailableDate = spotsPerDate
+            .entrySet()
+            .stream()
+            .filter(e -> e.getValue() > 0) // get all entries in the map that have a spot left
+            .map(Map.Entry::getKey) // get the dates (which are the keys in the map)
+            .sorted() // order the keys
+            .findFirst() // get the first one
+            .get();
+
+        return firstAvailableDate;
+    }
+
+    // This method takes up a spot on the given date.
+    // You should not call this method with an invalid date.
+    // (In real code, you would want to write some defensive code here,
+    // we just don't do it for the sake of simplicity in the exam.)
+    public void takeASpot(ZonedDateTime date) {
+        spotsPerDate.put(date, spotsPerDate.get(date) - 1);
+    }
+
+    @Override
+    @GeneratedExcludeFromJacoco
+    public int hashCode() {
+        return Objects.hash(this.id, this.name, this.spotsPerDate);
+    }
+
+    @Override
+    @GeneratedExcludeFromJacoco
+    public boolean equals(Object o) {
+        // self check
+        if (this == o)
+            return true;
+        // null check
+        if (o == null)
+            return false;
+        // type check and cast
+        if (getClass() != o.getClass())
+            return false;
+        Workshop other = (Workshop) o;
+        // field comparison
+        return Objects.equals(id, other.id)
+                && Objects.equals(name, other.name)
+                && Objects.equals(spotsPerDate, other.spotsPerDate);
+    }
+}
+
+// In real life, this class would assign students to workshops
+// by means of, e.g., persisting new information in a database.
+// For the sake of simplicity in this exam, we just store this information as a log.
+class AssignmentsLogger {
+    private final List<String> errors = new ArrayList<String>();
+    private final List<String> assignments = new ArrayList<String>();
+    // The formatter generates strings like "13/07/2022 14:00"
+    private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm");
+
+    public void noAvailableSpots(Workshop workshop, Student student) {
+        // Example of the added string: "Python,Frank"
+        errors.add(String.format("%s,%s", workshop.getName(), student.getName()));
+    }
+
+    public void assign(Workshop workshop, Student student, ZonedDateTime date) {
+        // Example of the added string: "Java,Mauricio,13/07/2022 14:00"
+        assignments.add(String.format("%s,%s,%s", workshop.getName(), student.getName(), format(date)));
+    }
+
+    public List<String> getErrors() {
+        return Collections.unmodifiableList(errors);
+    }
+
+    public List<String> getAssignments() {
+        return Collections.unmodifiableList(assignments);
+    }
+
+    private String format(ZonedDateTime date) {
+        return date.format(formatter);
+    }
+}
+
+
+class AutoAssigner {
+    public AssignmentsLogger assign(List<Student> students, 
+      List<Workshop> workshops) {
+
+          AssignmentsLogger assignments = new AssignmentsLogger();
+
+          for(Workshop workshop : workshops) {
+              for(Student student : students) {
+                // Get the next available date for that workshop
+                // If there's no way, nothing we can do, just log it!
+                if(!workshop.hasAvailableDate()) {
+                    assignments.noAvailableSpots(workshop, student);
+                } else {
+                    // Great, that workshop has an available date!
+                    // Let's assign the student to that workshop on that specific date
+                    ZonedDateTime nextDate = workshop.getNextAvailableDate();
+                    assignments.assign(workshop, student, nextDate);
+                    workshop.takeASpot(nextDate);
+                }
+              }
+          }
+
+          return assignments;
+
+    }
+
+}

--- a/src/test/resources/grader/fixtures/Solution/AutoAssignerOfficialSolution.java
+++ b/src/test/resources/grader/fixtures/Solution/AutoAssignerOfficialSolution.java
@@ -1,0 +1,145 @@
+package delft;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.within;
+import java.time.temporal.ChronoUnit;
+
+import java.util.*;
+import java.util.stream.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.*;
+import org.junit.jupiter.params.provider.*;
+import java.time.*;
+
+class AutoAssignerTest {
+
+    @Test
+    void all_students_in_the_same_first_date() {
+        List<Student> students = Arrays.asList(
+            new Student(1, "Mauricio", "mauricio@tudelft.nl"),
+            new Student(2, "Frank", "frank@tudelft.nl")
+        );
+
+        List<Workshop> workshops = Arrays.asList(
+            new Workshop(1, "Java", new HashMap<>() {{
+                put(date(2022, 1, 1, 14, 0), 5);
+            }}),
+            new Workshop(2, "Networks", new HashMap<>() {{
+                put(date(2022, 1, 2, 14, 0), 5);
+            }})
+        );
+
+        AutoAssigner assigner = new AutoAssigner();
+        AssignmentsLogger result = assigner.assign(students, workshops);
+
+        assertThat(result.getErrors()).isEmpty();
+        assertThat(result.getAssignments()).containsExactlyInAnyOrder(
+            "Java,Mauricio,01/01/2022 14:00",
+            "Java,Frank,01/01/2022 14:00",
+            "Networks,Mauricio,02/01/2022 14:00",
+            "Networks,Frank,02/01/2022 14:00"
+        );
+    }
+
+    @Test
+    void uses_different_dates() {
+        List<Student> students = Arrays.asList(
+            new Student(1, "Mauricio", "mauricio@tudelft.nl"),
+            new Student(2, "Frank", "frank@tudelft.nl"),
+            new Student(3, "Martin", "martin@tudelft.nl"),
+            new Student(4, "Sara", "sara@tudelft.nl")
+        );
+
+        List<Workshop> workshops = Arrays.asList(
+            new Workshop(1, "Java", new HashMap<>() {{
+                put(date(2022, 1, 1, 14, 0), 1);
+                put(date(2022, 1, 1, 17, 0), 2);
+                put(date(2022, 1, 1, 19, 0), 1);
+            }}),
+            new Workshop(2, "Networks", new HashMap<>() {{
+                put(date(2022, 1, 2, 14, 0), 1);
+                put(date(2022, 1, 2, 17, 0), 2);
+                put(date(2022, 1, 2, 19, 0), 1);
+            }})
+        );
+
+        AutoAssigner assigner = new AutoAssigner();
+        AssignmentsLogger result = assigner.assign(students, workshops);
+
+        assertThat(result.getErrors()).isEmpty();
+        assertThat(result.getAssignments()).containsExactlyInAnyOrder(
+            "Java,Mauricio,01/01/2022 14:00",
+            "Java,Frank,01/01/2022 17:00",
+            "Java,Martin,01/01/2022 17:00",
+            "Java,Sara,01/01/2022 19:00",
+            "Networks,Mauricio,02/01/2022 14:00",
+            "Networks,Frank,02/01/2022 17:00",
+            "Networks,Martin,02/01/2022 17:00",
+            "Networks,Sara,02/01/2022 19:00"
+        );
+    }
+
+    @Test
+    void no_spaces_for_everybody() {
+        List<Student> students = Arrays.asList(
+            new Student(1, "Mauricio", "mauricio@example.com"),
+            new Student(2, "Frank", "frank@example.com")
+        );
+
+        List<Workshop> workshops = Arrays.asList(
+            new Workshop(1, "Java", new HashMap<>() {{
+                put(date(2022, 1, 1, 14, 0), 1);
+            }}),
+            new Workshop(2, "Networks", new HashMap<>() {{
+                put(date(2022, 1, 2, 14, 0), 1);
+            }})
+        );
+
+        AutoAssigner assigner = new AutoAssigner();
+        AssignmentsLogger result = assigner.assign(students, workshops);
+
+        assertThat(result.getErrors()).containsExactlyInAnyOrder(
+            "Java,Frank",
+            "Networks,Frank"
+        );
+        assertThat(result.getAssignments()).containsExactlyInAnyOrder(
+            "Java,Mauricio,01/01/2022 14:00",
+            "Networks,Mauricio,02/01/2022 14:00"
+        );
+    }
+
+    // corner cases
+    @Test
+    void everything_full() {
+        List<Student> students = Arrays.asList(
+            new Student(1, "Mauricio", "mauricio@example.com"),
+            new Student(2, "Frank", "frank@example.com")
+        );
+
+        List<Workshop> workshops = Arrays.asList(
+            new Workshop(1, "Java", new HashMap<>() {{
+                put(date(2022, 1, 1, 14, 0), 0);
+                put(date(2022, 1, 1, 17, 0), 0);
+            }}),
+            new Workshop(2, "Networks", new HashMap<>() {{
+                put(date(2022, 1, 2, 14, 0), 0);
+                put(date(2022, 1, 2, 17, 0), 0);
+            }})
+        );
+
+        AutoAssigner assigner = new AutoAssigner();
+        AssignmentsLogger result = assigner.assign(students, workshops);
+
+        assertThat(result.getErrors()).containsExactlyInAnyOrder(
+            "Java,Mauricio","Networks,Mauricio",
+            "Java,Frank","Networks,Frank");
+        assertThat(result.getAssignments()).isEmpty();
+    }
+
+    private ZonedDateTime date(int year, int month, int day, int hour, int minute) {
+        return ZonedDateTime.of(year, month, day, hour, minute, 0, 0, ZoneId.systemDefault());
+    }
+
+
+}


### PR DESCRIPTION
I added the annotation in a new `delft` package inside Andy so that it can directly be used in the library without the need to import it.

Closes #127 