### PR TITLE
Change name of `startLine` and `endLine` properties in highlight JSON

### DIFF
--- a/andy/src/main/java/nl/tudelft/cse1110/andy/writer/weblab/EditorFeedbackRange.java
+++ b/andy/src/main/java/nl/tudelft/cse1110/andy/writer/weblab/EditorFeedbackRange.java
@@ -3,7 +3,7 @@ package nl.tudelft.cse1110.andy.writer.weblab;
 import com.google.gson.annotations.SerializedName;
 
 public record EditorFeedbackRange(EditorFeedbackLocation location,
-                                  long startLine, long endLine,
+                                  long startLineNumber, long endLineNumber,
                                   EditorFeedbackSeverity severity,
                                   String message) {
 
@@ -11,15 +11,15 @@ public record EditorFeedbackRange(EditorFeedbackLocation location,
      * [
      *     {
      *         "location": "SOLUTION", //one of ["LIBRARY", "SOLUTION", "TEST"]
-     *         "startLine": 20, //int
-     *         "endLine": 20, //int
+     *         "startLineNumber": 20, //int
+     *         "endLineNumber": 20, //int
      *         "severity": "Info", //one of ["Error", "Hint", "Info", "Warning"]
      *         "message": "100% coverage" //String
      *     },
      *     {
      *         "location": "LIBRARY",
-     *         "startLine": 41,
-     *         "endLine": 48,
+     *         "startLineNumber": 41,
+     *         "endLineNumber": 48,
      *         "severity": "Info",
      *         "message": "Some message"
      *     },

--- a/andy/src/test/java/unit/writer/weblab/WebLabEditorFeedbackJsonTestAssertions.java
+++ b/andy/src/test/java/unit/writer/weblab/WebLabEditorFeedbackJsonTestAssertions.java
@@ -32,8 +32,8 @@ public class WebLabEditorFeedbackJsonTestAssertions {
 
     private static Condition<String> line(int start, int end, String message, String location, String purpose) {
         return containsString(String.format("{\"location\":\"%s\"," +
-                                            "\"startLine\":%d," +
-                                            "\"endLine\":%d," +
+                                            "\"startLineNumber\":%d," +
+                                            "\"endLineNumber\":%d," +
                                             "\"severity\":\"%s\"," +
                                             "\"message\":\"%s\"}",
                 location, start, end, purpose, message));


### PR DESCRIPTION
In WebLab we decided to change `startLine` and `endLine` to `startLineNumber` and `endLineNumber` in the highlight JSON file. This simple PR changes the need to edit it yourself.