### PR TITLE
Change "location" property in editor feedback to "file"

### DIFF
--- a/andy/src/main/java/nl/tudelft/cse1110/andy/writer/weblab/EditorFeedbackRange.java
+++ b/andy/src/main/java/nl/tudelft/cse1110/andy/writer/weblab/EditorFeedbackRange.java
@@ -2,7 +2,7 @@ package nl.tudelft.cse1110.andy.writer.weblab;
 
 import com.google.gson.annotations.SerializedName;
 
-public record EditorFeedbackRange(EditorFeedbackLocation location,
+public record EditorFeedbackRange(EditorFeedbackFile file,
                                   long startLineNumber, long endLineNumber,
                                   EditorFeedbackSeverity severity,
                                   String message) {
@@ -10,14 +10,16 @@ public record EditorFeedbackRange(EditorFeedbackLocation location,
     /*
      * [
      *     {
-     *         "location": "SOLUTION", //one of ["LIBRARY", "SOLUTION", "TEST"]
+     *         "file": "SOLUTION", //one of ["LIBRARY", "SOLUTION", "TEST"]
      *         "startLineNumber": 20, //int
      *         "endLineNumber": 20, //int
      *         "severity": "Info", //one of ["Error", "Hint", "Info", "Warning"]
      *         "message": "100% coverage" //String
+     *          // "startColumn": 1, //optional, int
+     *          // "endColumn": 20 //optional, int
      *     },
      *     {
-     *         "location": "LIBRARY",
+     *         "file": "LIBRARY",
      *         "startLineNumber": 41,
      *         "endLineNumber": 48,
      *         "severity": "Info",
@@ -38,7 +40,7 @@ public record EditorFeedbackRange(EditorFeedbackLocation location,
         WARNING
     }
 
-    public enum EditorFeedbackLocation {
+    public enum EditorFeedbackFile {
         @SerializedName("LIBRARY")
         LIBRARY,
         @SerializedName("SOLUTION")

--- a/andy/src/main/java/nl/tudelft/cse1110/andy/writer/weblab/WebLabResultWriter.java
+++ b/andy/src/main/java/nl/tudelft/cse1110/andy/writer/weblab/WebLabResultWriter.java
@@ -8,7 +8,7 @@ import nl.tudelft.cse1110.andy.writer.standard.CodeSnippetGenerator;
 import nl.tudelft.cse1110.andy.writer.standard.RandomAsciiArtGenerator;
 import nl.tudelft.cse1110.andy.writer.standard.StandardResultWriter;
 import nl.tudelft.cse1110.andy.writer.standard.VersionInformation;
-import nl.tudelft.cse1110.andy.writer.weblab.EditorFeedbackRange.EditorFeedbackLocation;
+import nl.tudelft.cse1110.andy.writer.weblab.EditorFeedbackRange.EditorFeedbackFile;
 import nl.tudelft.cse1110.andy.writer.weblab.EditorFeedbackRange.EditorFeedbackSeverity;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -160,25 +160,25 @@ public class WebLabResultWriter extends StandardResultWriter {
         editorFeedbackRanges.addAll(aggregateLinesIntoRanges(
                 result.getCoverage().getFullyCoveredLines(),
                 "100% coverage",
-                EditorFeedbackLocation.LIBRARY,
+                EditorFeedbackFile.LIBRARY,
                 EditorFeedbackSeverity.INFO));
 
         editorFeedbackRanges.addAll(aggregateLinesIntoRanges(
                 result.getCoverage().getPartiallyCoveredLines(),
                 "Partial coverage",
-                EditorFeedbackLocation.LIBRARY,
+                EditorFeedbackFile.LIBRARY,
                 EditorFeedbackSeverity.HINT));
 
         editorFeedbackRanges.addAll(aggregateLinesIntoRanges(
                 result.getCoverage().getNotCoveredLines(),
                 "No coverage",
-                EditorFeedbackLocation.LIBRARY,
+                EditorFeedbackFile.LIBRARY,
                 EditorFeedbackSeverity.WARNING));
 
         // compilation error
         for (CompilationErrorInfo error : result.getCompilation().getErrors()) {
             editorFeedbackRanges.add(new EditorFeedbackRange(
-                    EditorFeedbackLocation.SOLUTION,
+                    EditorFeedbackFile.SOLUTION,
                     error.getLineNumber(),
                     error.getLineNumber(),
                     EditorFeedbackSeverity.ERROR,
@@ -189,7 +189,7 @@ public class WebLabResultWriter extends StandardResultWriter {
     }
 
     private List<EditorFeedbackRange> aggregateLinesIntoRanges(
-            List<Integer> lines, String message, EditorFeedbackLocation location, EditorFeedbackSeverity severity) {
+            List<Integer> lines, String message, EditorFeedbackFile file, EditorFeedbackSeverity severity) {
         // Convert list of line numbers, e.g. [2,4,8,3,10,7]
         // into a list of ranges, e.g. [(2,4),(7,8),(10,10)]
 
@@ -203,7 +203,7 @@ public class WebLabResultWriter extends StandardResultWriter {
         for (int i = 0; i < sortedLines.size(); i++) {
             int currLine = sortedLines.get(i);
             if (i == sortedLines.size() - 1 || currLine + 1 != sortedLines.get(i + 1)) {
-                ranges.add(new EditorFeedbackRange(location, currRangeStart, currLine, severity, message));
+                ranges.add(new EditorFeedbackRange(file, currRangeStart, currLine, severity, message));
                 if (i != sortedLines.size() - 1) currRangeStart = sortedLines.get(i + 1);
             }
         }

--- a/andy/src/test/java/unit/writer/weblab/WebLabEditorFeedbackJsonTestAssertions.java
+++ b/andy/src/test/java/unit/writer/weblab/WebLabEditorFeedbackJsonTestAssertions.java
@@ -30,13 +30,13 @@ public class WebLabEditorFeedbackJsonTestAssertions {
         return line(start, end, message, "SOLUTION", purpose);
     }
 
-    private static Condition<String> line(int start, int end, String message, String location, String purpose) {
-        return containsString(String.format("{\"location\":\"%s\"," +
+    private static Condition<String> line(int start, int end, String message, String file, String purpose) {
+        return containsString(String.format("{\"file\":\"%s\"," +
                                             "\"startLineNumber\":%d," +
                                             "\"endLineNumber\":%d," +
                                             "\"severity\":\"%s\"," +
                                             "\"message\":\"%s\"}",
-                location, start, end, purpose, message));
+                file, start, end, purpose, message));
     }
 
 }


### PR DESCRIPTION
The title says it all, we changed the editor feedback format in WebLab such that the "location" property is now called "file", this PR makes Andy's editor feedback compatible again.