### PR TITLE
Tagging tests that are meant to run in CI

### DIFF
--- a/andy/src/test/java/selenium/AllExerciseTests.java
+++ b/andy/src/test/java/selenium/AllExerciseTests.java
@@ -1,5 +1,6 @@
 package selenium;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -15,6 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static unit.writer.standard.StandardResultTestAssertions.compilationSuccess;
 import static unit.writer.standard.StandardResultTestAssertions.finalGrade;
 
+@Tag("ci")
 public class AllExerciseTests extends WebLabSeleniumTestBase {
 
     protected static final String BASE_ASSIGNMENT_ID = "91800";

--- a/andy/src/test/java/selenium/ExamAssignmentTests.java
+++ b/andy/src/test/java/selenium/ExamAssignmentTests.java
@@ -1,6 +1,7 @@
 package selenium;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -15,6 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.not;
 import static unit.writer.standard.StandardResultTestAssertions.*;
 
+@Tag("ci")
 public class ExamAssignmentTests extends WebLabSeleniumTestBase {
 
     private static final String ASSIGNMENT_EXAM = "89106";

--- a/andy/src/test/java/selenium/PracticeAssignmentTests.java
+++ b/andy/src/test/java/selenium/PracticeAssignmentTests.java
@@ -1,6 +1,7 @@
 package selenium;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import selenium.pageobjects.WebLabSubmissionPage;
 
@@ -10,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.not;
 import static unit.writer.standard.StandardResultTestAssertions.*;
 
+@Tag("ci")
 public class PracticeAssignmentTests extends WebLabSeleniumTestBase {
 
     private static final String ASSIGNMENT_PRACTICE = "89104";

--- a/andy/src/test/java/selenium/SecurityExploitTests.java
+++ b/andy/src/test/java/selenium/SecurityExploitTests.java
@@ -1,5 +1,6 @@
 package selenium;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import selenium.pageobjects.WebLabSubmissionPage;
@@ -9,6 +10,7 @@ import java.io.IOException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static unit.writer.standard.StandardResultTestAssertions.*;
 
+@Tag("ci")
 public class SecurityExploitTests extends WebLabSeleniumTestBase {
 
     private static final String ASSIGNMENT_PRACTICE = "89104";


### PR DESCRIPTION
In MR adds `@Tag` to tests that are more meant to be run in the CI. For example, the WebLab tests that require extra configuration. Tags make it easy for us to exclude them in local (via a simple JUnit configuration).