### PR TITLE
Coverage doesn't require the tests to run again

### DIFF
--- a/andy/src/main/java/nl/tudelft/cse1110/andy/execution/Context.java
+++ b/andy/src/main/java/nl/tudelft/cse1110/andy/execution/Context.java
@@ -7,6 +7,8 @@ import nl.tudelft.cse1110.andy.execution.mode.Action;
 import nl.tudelft.cse1110.andy.execution.mode.ModeActionSelector;
 import nl.tudelft.cse1110.andy.execution.externalprocess.ExternalProcess;
 import nl.tudelft.cse1110.andy.writer.weblab.SubmissionMetaData;
+import org.jacoco.core.runtime.IRuntime;
+import org.jacoco.core.runtime.RuntimeData;
 
 import java.util.List;
 
@@ -22,6 +24,8 @@ public class Context {
     private ExternalProcess externalProcess;
     private SubmissionMetaData submissionMetaData;
     private ClassLoader classloaderWithStudentsCode;
+    private IRuntime jacocoRuntime;
+    private RuntimeData jacocoData;
 
     public Context(Action action) {
         this(Thread.currentThread().getContextClassLoader(), action);
@@ -108,5 +112,22 @@ public class Context {
 
     public ClassLoader getClassloaderWithStudentsCode() {
         return classloaderWithStudentsCode;
+    }
+
+    public void setJacocoObjects(IRuntime runtime, RuntimeData data) {
+        jacocoRuntime = runtime;
+        jacocoData = data;
+    }
+
+    public boolean hasJacocoRuntime() {
+        return jacocoRuntime != null && jacocoData != null;
+    }
+
+    public IRuntime getJacocoRuntime() {
+        return jacocoRuntime;
+    }
+
+    public RuntimeData getJacocoData() {
+        return jacocoData;
     }
 }

--- a/andy/src/main/java/nl/tudelft/cse1110/andy/execution/mode/Action.java
+++ b/andy/src/main/java/nl/tudelft/cse1110/andy/execution/mode/Action.java
@@ -1,5 +1,9 @@
 package nl.tudelft.cse1110.andy.execution.mode;
 
 public enum Action {
-    FULL_WITH_HINTS, FULL_WITHOUT_HINTS, COVERAGE, TESTS, META_TEST
+    FULL_WITH_HINTS, /* Runs all analysis, and provides hints to students */
+    FULL_WITHOUT_HINTS, /* Runs the full analysis, gives the grade, but no hints */
+    COVERAGE, /* Runs mutation testing besides coverage */
+    TESTS, /* Runs the tests with coverage */
+    META_TEST /* Internal use only */
 }

--- a/andy/src/main/java/nl/tudelft/cse1110/andy/execution/mode/ModeActionSelector.java
+++ b/andy/src/main/java/nl/tudelft/cse1110/andy/execution/mode/ModeActionSelector.java
@@ -75,17 +75,17 @@ public class ModeActionSelector {
         if (action == FULL_WITH_HINTS || action == FULL_WITHOUT_HINTS) {
             return fullMode();
         } else if (action == COVERAGE) {
-            return withCoverage();
+            return withMutationCoverage();
         } else {
-            return justTests();
+            return testsAndCoverage();
         }
     }
 
     private List<ExecutionStep> getExamMode() {
         if (action == FULL_WITH_HINTS || action == FULL_WITHOUT_HINTS || action == COVERAGE) {
-            return withCoverage();
+            return withMutationCoverage();
         } else {
-            return justTests();
+            return testsAndCoverage();
         }
     }
 
@@ -100,15 +100,20 @@ public class ModeActionSelector {
         return List.of(new RunJUnitTestsStep());
     }
 
-    public static List<ExecutionStep> justTests() {
-        return List.of(new RunExternalProcessStep(), new RunJUnitTestsStep());
-    }
-
-    public static List<ExecutionStep> withCoverage() {
+    public static List<ExecutionStep> testsAndCoverage() {
         return List.of(
                 new RunExternalProcessStep(),
+                new InstrumentCodeForCoverageStep(),
                 new RunJUnitTestsStep(),
-                new RunJacocoCoverageStep(),
+                new CollectCoverageInformationStep());
+    }
+
+    public static List<ExecutionStep> withMutationCoverage() {
+        return List.of(
+                new RunExternalProcessStep(),
+                new InstrumentCodeForCoverageStep(),
+                new RunJUnitTestsStep(),
+                new CollectCoverageInformationStep(),
                 new RunPitestStep()
         );
     }
@@ -116,8 +121,9 @@ public class ModeActionSelector {
     public static List<ExecutionStep> fullMode() {
         return List.of(
                 new RunExternalProcessStep(),
+                new InstrumentCodeForCoverageStep(),
                 new RunJUnitTestsStep(),
-                new RunJacocoCoverageStep(),
+                new CollectCoverageInformationStep(),
                 new RunPitestStep(),
                 new RunRequiredCodeChecksStep(),
                 new RunCodeChecksStep(),

--- a/andy/src/main/java/nl/tudelft/cse1110/andy/execution/step/CollectCoverageInformationStep.java
+++ b/andy/src/main/java/nl/tudelft/cse1110/andy/execution/step/CollectCoverageInformationStep.java
@@ -4,25 +4,22 @@ import nl.tudelft.cse1110.andy.config.DirectoryConfiguration;
 import nl.tudelft.cse1110.andy.config.RunConfiguration;
 import nl.tudelft.cse1110.andy.execution.Context;
 import nl.tudelft.cse1110.andy.execution.ExecutionStep;
-import nl.tudelft.cse1110.andy.utils.FromBytesClassLoader;
 import nl.tudelft.cse1110.andy.result.ResultBuilder;
 import nl.tudelft.cse1110.andy.utils.ClassUtils;
 import nl.tudelft.cse1110.andy.utils.FilesUtils;
-import org.jacoco.core.analysis.*;
+import nl.tudelft.cse1110.andy.utils.FromBytesClassLoader;
+import org.jacoco.core.analysis.Analyzer;
+import org.jacoco.core.analysis.CoverageBuilder;
+import org.jacoco.core.analysis.IClassCoverage;
 import org.jacoco.core.data.ExecutionDataStore;
 import org.jacoco.core.data.SessionInfoStore;
 import org.jacoco.core.instr.Instrumenter;
 import org.jacoco.core.runtime.IRuntime;
-import org.jacoco.core.runtime.LoggerRuntime;
 import org.jacoco.core.runtime.RuntimeData;
 import org.jacoco.report.DirectorySourceFileLocator;
 import org.jacoco.report.FileMultiReportOutput;
 import org.jacoco.report.IReportVisitor;
 import org.jacoco.report.html.HTMLFormatter;
-import org.junit.platform.launcher.Launcher;
-import org.junit.platform.launcher.LauncherDiscoveryRequest;
-import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
-import org.junit.platform.launcher.core.LauncherFactory;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -32,9 +29,8 @@ import java.util.Collection;
 
 import static nl.tudelft.cse1110.andy.utils.ClassUtils.clazzNameAsPath;
 import static nl.tudelft.cse1110.andy.utils.FilesUtils.concatenateDirectories;
-import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
 
-public class RunJacocoCoverageStep implements ExecutionStep {
+public class CollectCoverageInformationStep implements ExecutionStep {
 
     @Override
     public void execute(Context ctx, ResultBuilder result) {
@@ -44,36 +40,17 @@ public class RunJacocoCoverageStep implements ExecutionStep {
             return;
         }
 
+        if(!ctx.hasJacocoRuntime()) {
+            throw new RuntimeException("Failed when getting coverage information!");
+        }
+
         DirectoryConfiguration dirCfg = ctx.getDirectoryConfiguration();
         RunConfiguration runCfg = ctx.getRunConfiguration();
 
+        RuntimeData data = ctx.getJacocoData();
+        IRuntime runtime = ctx.getJacocoRuntime();
+
         try {
-            /* Get the names of the test class and the library classes.*/
-            String testClass = ClassUtils.getTestClass(ctx.getNewClassNames());
-
-            final IRuntime runtime = new LoggerRuntime();
-
-            /*
-             * We need to instrument the SUT to be able to generate a JaCoCo report.
-             * We then override the non-instrumented classes with the instrumented ones using
-             * a custom class loader. For the sake of simplicity we instrument all classes using a custom method.
-             * We also save the old class loader to restore it later.
-             */
-            final Instrumenter instr = new Instrumenter(runtime);
-
-            ClassLoader currentClassLoader = Thread.currentThread().getContextClassLoader();
-            FromBytesClassLoader classLoader = new FromBytesClassLoader(currentClassLoader);
-
-            this.instrumentAllInDirectory(instr, new File(dirCfg.getWorkingDir()), classLoader, "");
-
-            Thread.currentThread().setContextClassLoader(classLoader);
-
-            final RuntimeData data = new RuntimeData();
-            runtime.startup(data);
-
-            /* After instrumenting classes, we need to execute them.*/
-            this.executeJUnitTests(testClass);
-
             /*
              * After instrumenting and running, we can continue to reporting.
              * This will generate the JaCoCo report.
@@ -100,12 +77,13 @@ public class RunJacocoCoverageStep implements ExecutionStep {
             result.logJacoco(coverages);
 
             /* Generate an HTML report.*/
+            String testClass = ClassUtils.getTestClass(ctx.getNewClassNames());
             this.generateReport(dirCfg, testClass, coverageBuilder, executionData, sessionInfos);
-
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        } finally {
             /* Restore the old class loader to get the non-instrumented classes back.*/
-            Thread.currentThread().setContextClassLoader(currentClassLoader);
-        } catch (Exception ex) {
-            result.genericFailure(this, ex);
+            Thread.currentThread().setContextClassLoader(ctx.getClassloaderWithStudentsCode());
         }
     }
 
@@ -138,17 +116,6 @@ public class RunJacocoCoverageStep implements ExecutionStep {
         return new FileInputStream(pathToClass);
     }
 
-    /* Run the specified JUnit test file */
-    private void executeJUnitTests(String testClass) {
-        Launcher launcher = LauncherFactory.create();
-
-        LauncherDiscoveryRequest request = LauncherDiscoveryRequestBuilder.request()
-                .selectors(selectClass(testClass))
-                .configurationParameter("jqwik.database", FilesUtils.createTemporaryDirectory("jqwik").resolve("jqwik-db").toString())
-                .build();
-        launcher.execute(request);
-    }
-
     /* Generate an HTML report from JaCoCo based on the coverage analysis of our classes. */
     private void generateReport(DirectoryConfiguration dirCfg, String testClass,
                                 CoverageBuilder coverageBuilder, ExecutionDataStore executionData,
@@ -172,6 +139,6 @@ public class RunJacocoCoverageStep implements ExecutionStep {
 
     @Override
     public boolean equals(Object other) {
-        return other instanceof RunJacocoCoverageStep;
+        return other instanceof CollectCoverageInformationStep;
     }
 }

--- a/andy/src/main/java/nl/tudelft/cse1110/andy/execution/step/InstrumentCodeForCoverageStep.java
+++ b/andy/src/main/java/nl/tudelft/cse1110/andy/execution/step/InstrumentCodeForCoverageStep.java
@@ -1,0 +1,105 @@
+package nl.tudelft.cse1110.andy.execution.step;
+
+import nl.tudelft.cse1110.andy.config.DirectoryConfiguration;
+import nl.tudelft.cse1110.andy.config.RunConfiguration;
+import nl.tudelft.cse1110.andy.execution.Context;
+import nl.tudelft.cse1110.andy.execution.ExecutionStep;
+import nl.tudelft.cse1110.andy.result.ResultBuilder;
+import nl.tudelft.cse1110.andy.utils.ClassUtils;
+import nl.tudelft.cse1110.andy.utils.FilesUtils;
+import nl.tudelft.cse1110.andy.utils.FromBytesClassLoader;
+import org.jacoco.core.analysis.Analyzer;
+import org.jacoco.core.analysis.CoverageBuilder;
+import org.jacoco.core.analysis.IClassCoverage;
+import org.jacoco.core.data.ExecutionDataStore;
+import org.jacoco.core.data.SessionInfoStore;
+import org.jacoco.core.instr.Instrumenter;
+import org.jacoco.core.runtime.IRuntime;
+import org.jacoco.core.runtime.LoggerRuntime;
+import org.jacoco.core.runtime.RuntimeData;
+import org.jacoco.report.DirectorySourceFileLocator;
+import org.jacoco.report.FileMultiReportOutput;
+import org.jacoco.report.IReportVisitor;
+import org.jacoco.report.html.HTMLFormatter;
+import org.junit.platform.launcher.Launcher;
+import org.junit.platform.launcher.LauncherDiscoveryRequest;
+import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
+import org.junit.platform.launcher.core.LauncherFactory;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collection;
+
+import static nl.tudelft.cse1110.andy.utils.ClassUtils.clazzNameAsPath;
+import static nl.tudelft.cse1110.andy.utils.FilesUtils.concatenateDirectories;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+
+public class InstrumentCodeForCoverageStep implements ExecutionStep {
+
+    @Override
+    public void execute(Context ctx, ResultBuilder result) {
+
+        // Skip step if disabled
+        if (ctx.getRunConfiguration().skipJacoco()) {
+            return;
+        }
+
+        DirectoryConfiguration dirCfg = ctx.getDirectoryConfiguration();
+
+        try {
+            IRuntime runtime = new LoggerRuntime();
+
+            /*
+             * We need to instrument the SUT to be able to generate a JaCoCo report.
+             * We then override the non-instrumented classes with the instrumented ones using
+             * a custom class loader. For the sake of simplicity we instrument all classes using a custom method.
+             * We also save the old class loader to restore it later.
+             */
+            final Instrumenter instr = new Instrumenter(runtime);
+
+            ClassLoader currentClassLoader = Thread.currentThread().getContextClassLoader();
+            FromBytesClassLoader classLoaderWithInstrumentedClasses = new FromBytesClassLoader(currentClassLoader);
+
+            this.instrumentAllInDirectory(instr, new File(dirCfg.getWorkingDir()), classLoaderWithInstrumentedClasses, "");
+
+            Thread.currentThread().setContextClassLoader(classLoaderWithInstrumentedClasses);
+
+            final RuntimeData data = new RuntimeData();
+            runtime.startup(data);
+
+            ctx.setJacocoObjects(runtime, data);
+
+        } catch (Exception ex) {
+            result.genericFailure(this, ex);
+        }
+    }
+
+    /**Instrument all classes in a directory.*/
+    private void instrumentAllInDirectory(Instrumenter instr, File directory, FromBytesClassLoader classLoader, String start) throws IOException {
+        File[] files = directory.listFiles();
+
+        for (File file : files) {
+            if (file.isFile() && file.getName().endsWith(".class")) {
+                InputStream originalLibrary = new FileInputStream(file.getAbsolutePath());
+                String className = start + "." + file.getName().replace(".class", "").replace('/', '.');
+
+                final byte[] instrumentedLibrary = instr.instrument(originalLibrary, className);
+                originalLibrary.close();
+                classLoader.addDefinition(className, instrumentedLibrary);
+            } else if (file.isDirectory()) {
+                if (!start.equals("")) {
+                    instrumentAllInDirectory(instr, file, classLoader, start + "." + file.getName());
+                } else {
+                    instrumentAllInDirectory(instr, file, classLoader, file.getName());
+                }
+            }
+        }
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof InstrumentCodeForCoverageStep;
+    }
+}

--- a/andy/src/main/java/nl/tudelft/cse1110/andy/execution/step/RunJUnitTestsStep.java
+++ b/andy/src/main/java/nl/tudelft/cse1110/andy/execution/step/RunJUnitTestsStep.java
@@ -26,7 +26,6 @@ public class RunJUnitTestsStep implements ExecutionStep {
     @Override
     public void execute(Context ctx, ResultBuilder result) {
         try {
-
             SummaryGeneratingListener listener = new SummaryGeneratingListener();
             AdditionalReportJUnitListener additionalReportJUnitListener = new AdditionalReportJUnitListener(result);
 

--- a/andy/src/test/java/integration/JacocoTest.java
+++ b/andy/src/test/java/integration/JacocoTest.java
@@ -19,7 +19,7 @@ public class JacocoTest extends IntegrationTestBase {
     @ParameterizedTest
     @MethodSource("generator")
     void differentCoverages(String library, String solution, int lines, int instructions, int branches) {
-        Result result = run(Action.COVERAGE, library, solution);
+        Result result = run(Action.TESTS, library, solution);
 
         assertThat(result.getCoverage().wasExecuted()).isTrue();
 
@@ -53,7 +53,7 @@ public class JacocoTest extends IntegrationTestBase {
 
     @Test
     void nestedClassesInLibrary() {
-        Result result = run(Action.COVERAGE,
+        Result result = run(Action.TESTS,
                 "CollectionUtilsIsEqualCollectionLibrary",
                 "CollectionUtilsIsEqualCollectionFullCoverage",
                 "CollectionUtilsIsEqualCollectionCoverageConfiguration");
@@ -68,7 +68,7 @@ public class JacocoTest extends IntegrationTestBase {
     @ParameterizedTest
     @MethodSource("coveredLinesGenerator")
     void coveredAndUncoveredLines(String library, String solution, List<Integer> coveredLines, List<Integer> partiallyCovered, List<Integer> notCovered) {
-        Result result = run(Action.COVERAGE, library, solution);
+        Result result = run(Action.TESTS, library, solution);
 
         assertThat(result.getCoverage().getFullyCoveredLines()).isEqualTo(coveredLines);
         assertThat(result.getCoverage().getPartiallyCoveredLines()).isEqualTo(partiallyCovered);
@@ -90,7 +90,7 @@ public class JacocoTest extends IntegrationTestBase {
 
     @Test
     void jacocoDisabled() {
-        Result result = run(Action.COVERAGE, "NumberUtilsAddLibrary", "NumberUtilsAddSmoke", "NumberUtilsJacocoSkipped");
+        Result result = run(Action.TESTS, "NumberUtilsAddLibrary", "NumberUtilsAddSmoke", "NumberUtilsJacocoSkipped");
 
         assertThat(result.getCoverage().wasExecuted()).isFalse();
 

--- a/andy/src/test/java/integration/ModesAndActionsTest.java
+++ b/andy/src/test/java/integration/ModesAndActionsTest.java
@@ -76,7 +76,7 @@ public class ModesAndActionsTest extends IntegrationTestBase {
         assertThat(result.getTests().wasExecuted()).isTrue();
         assertThat(result.getTests().getTestsSucceeded()).isEqualTo(2);
 
-        assertThat(result.getCoverage().wasExecuted()).isFalse();
+        assertThat(result.getCoverage().wasExecuted()).isTrue(); // Since 2023, tests also run coverage
         assertThat(result.getMetaTests().wasExecuted()).isFalse();
         assertThat(result.getMutationTesting().wasExecuted()).isFalse();
         assertThat(result.getCodeChecks().wasExecuted()).isFalse();

--- a/andy/src/test/java/unit/execution/mode/ModeActionSelectorTest.java
+++ b/andy/src/test/java/unit/execution/mode/ModeActionSelectorTest.java
@@ -45,7 +45,7 @@ public class ModeActionSelectorTest {
         List<ExecutionStep> result = run(PRACTICE, COVERAGE);
 
         assertThat(result)
-                .containsExactlyElementsOf(ModeActionSelector.withCoverage());
+                .containsExactlyElementsOf(ModeActionSelector.withMutationCoverage());
     }
 
     @Test
@@ -53,7 +53,7 @@ public class ModeActionSelectorTest {
         List<ExecutionStep> result = run(PRACTICE, TESTS);
 
         assertThat(result)
-                .containsExactlyElementsOf(ModeActionSelector.justTests());
+                .containsExactlyElementsOf(ModeActionSelector.testsAndCoverage());
     }
 
     @Test
@@ -61,7 +61,7 @@ public class ModeActionSelectorTest {
         List<ExecutionStep> result = run(EXAM, COVERAGE);
 
         assertThat(result)
-                .containsExactlyElementsOf(ModeActionSelector.withCoverage());
+                .containsExactlyElementsOf(ModeActionSelector.withMutationCoverage());
     }
 
     @Test
@@ -69,7 +69,7 @@ public class ModeActionSelectorTest {
         List<ExecutionStep> result = run(EXAM, TESTS);
 
         assertThat(result)
-                .containsExactlyElementsOf(ModeActionSelector.justTests());
+                .containsExactlyElementsOf(ModeActionSelector.testsAndCoverage());
     }
 
     @Test


### PR DESCRIPTION
Currently, Andy re-runs the tests if we decide to collect coverage. With this MR, the engine follows the steps:

* Instruments all the code
* Runs JUnit
* Collects the data

This means we run the tests only once. Given that instrumenting the code is easy, we do this now also when "only running tests". We leave "coverage" now to the expensive coverage that's mutation testing.

This MR tackles issue #176 