### PR TITLE
Improve jqwik configs to speed up execution

### DIFF
--- a/andy/src/main/java/nl/tudelft/cse1110/andy/execution/step/RunJUnitTestsStep.java
+++ b/andy/src/main/java/nl/tudelft/cse1110/andy/execution/step/RunJUnitTestsStep.java
@@ -44,6 +44,8 @@ public class RunJUnitTestsStep implements ExecutionStep {
             LauncherDiscoveryRequest request = LauncherDiscoveryRequestBuilder.request()
                     .selectors(selectClass(clazz))
                     .configurationParameter("jqwik.reporting.usejunitplatform", "true")
+                    .configurationParameter("jqwik.tries.default", "100")
+                    .configurationParameter("jqwik.shrinking.default", "OFF")
                     .configurationParameter("jqwik.database", FilesUtils.createTemporaryDirectory("jqwik").resolve("jqwik-db").toString())
                     .build();
             launcher.execute(request);


### PR DESCRIPTION
This MR changes the following configs:

* jqwik.tries.default: Instead of running 1000 data points, we just run 100. Enough for teaching purposes.
* jqwik.shrinking.default: If it finds a bug, no need for shrinking, we want to return as early as possible.