### PR TITLE
R01: Rename file to avoid collision

### DIFF
--- a/assignments/property-based-testing/unique/src/main/java/delft/MathArraysPBT.java
+++ b/assignments/property-based-testing/unique/src/main/java/delft/MathArraysPBT.java
@@ -3,9 +3,9 @@ package delft;
 import java.util.Iterator;
 import java.util.TreeSet;
 
-class MathArrays {
+class MathArraysPBT {
 
-	private MathArrays() {
+	private MathArraysPBT() {
 		// Empty constructor
 	}
 


### PR DESCRIPTION
This MR renames `MathArrays` to `MathArraysPBT` to avoid name collision.